### PR TITLE
remove crossOrigin option

### DIFF
--- a/src/HTMLVideo/HTMLVideo.js
+++ b/src/HTMLVideo/HTMLVideo.js
@@ -22,7 +22,6 @@ function HTMLVideo(options) {
     videoElement.style.width = '100%';
     videoElement.style.height = '100%';
     videoElement.style.backgroundColor = 'black';
-    videoElement.crossOrigin = 'anonymous';
     videoElement.controls = false;
     videoElement.onerror = function() {
         onVideoError();


### PR DESCRIPTION
This attribute should be removed.
I am not sure why i added this option in the first place, but because of it, some mp4 streams does not work.
https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/crossorigin