### PR TITLE
Set 15m Timeout to HLS.js Segment Request

### DIFF
--- a/src/HTMLVideo/hlsConfig.js
+++ b/src/HTMLVideo/hlsConfig.js
@@ -11,5 +11,6 @@ module.exports = {
     nudgeMaxRetry: 20,
     manifestLoadingTimeOut: 30000,
     manifestLoadingMaxRetry: 10,
+    fragLoadingTimeOut: 900000,
     // liveDurationInfinity: false
 };


### PR DESCRIPTION
I am not 100% certain yet, but I think the low hls.js segment request timeout may have been locking up ffmpeg processes.