### PR TITLE
Update hls.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
         "deep-freeze": "0.0.1",
         "eventemitter3": "4.0.7",
         "hat": "0.0.3",
-        "hls.js": "https://github.com/Stremio/hls.js/releases/download/v1.2.3-patch1/hls.js-1.2.3-patch1.tgz",
+        "hls.js": "^1.5.0-alpha.0.0.canary.9602",
         "lodash.clonedeep": "4.5.0",
         "magnet-uri": "6.2.0",
         "url": "0.11.0",


### PR DESCRIPTION
This fixes "Video is not supported" when using the HTMLVideo on iOS (only for 17.1 beta 2 and up).