### PR TITLE
Set playsinline

### DIFF
--- a/src/HTMLVideo/HTMLVideo.js
+++ b/src/HTMLVideo/HTMLVideo.js
@@ -23,6 +23,7 @@ function HTMLVideo(options) {
     videoElement.style.height = '100%';
     videoElement.style.backgroundColor = 'black';
     videoElement.controls = false;
+    videoElement.playsInline = true;
     videoElement.onerror = function() {
         onVideoError();
     };


### PR DESCRIPTION
Prevents the video from going into "fullscreen" on iOS where Stremio controls are unavailable without pausing the video