### PR TITLE
fix(mediaCapabilities): remove force config for h265

### DIFF
--- a/src/mediaCapabilities.js
+++ b/src/mediaCapabilities.js
@@ -6,6 +6,8 @@ var VIDEO_CODEC_CONFIGS = [
     },
     {
         codec: 'h265',
+        // Disabled because chrome only has partial support for h265/hvec,
+        // force: window.chrome || window.cast,
         mime: 'video/mp4; codecs="hev1.1.6.L150.B0"',
         aliases: ['hevc']
     },

--- a/src/mediaCapabilities.js
+++ b/src/mediaCapabilities.js
@@ -6,7 +6,6 @@ var VIDEO_CODEC_CONFIGS = [
     },
     {
         codec: 'h265',
-        force: window.chrome || window.cast,
         mime: 'video/mp4; codecs="hev1.1.6.L150.B0"',
         aliases: ['hevc']
     },


### PR DESCRIPTION
Remove the `force` field for h265 that assumes that if it's chromium and has casting capabilities it doesn't need to be transcoded 