### PR TITLE
Increase Frag Retries to 20 (from 4)

### DIFF
--- a/src/HTMLVideo/hlsConfig.js
+++ b/src/HTMLVideo/hlsConfig.js
@@ -11,5 +11,21 @@ module.exports = {
     nudgeMaxRetry: 20,
     manifestLoadingTimeOut: 30000,
     manifestLoadingMaxRetry: 10,
+    fragLoadPolicy: {
+        default: {
+            maxTimeToFirstByteMs: 10000,
+            maxLoadTimeMs: 120000,
+            timeoutRetry: {
+                maxNumRetry: 15,
+                retryDelayMs: 0,
+                maxRetryDelayMs: 15
+            },
+            errorRetry: {
+                maxNumRetry: 6,
+                retryDelayMs: 1000,
+                maxRetryDelayMs: 15
+            }
+        }
+    }
     // liveDurationInfinity: false
 };

--- a/src/HTMLVideo/hlsConfig.js
+++ b/src/HTMLVideo/hlsConfig.js
@@ -16,7 +16,7 @@ module.exports = {
             maxTimeToFirstByteMs: 10000,
             maxLoadTimeMs: 120000,
             timeoutRetry: {
-                maxNumRetry: 15,
+                maxNumRetry: 20,
                 retryDelayMs: 0,
                 maxRetryDelayMs: 15
             },


### PR DESCRIPTION
The rest of the settings are the same as the defaults, only  `.timeoutRetry.maxNumRetry` is changed