### PR TITLE
Fix VTT.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
         "magnet-uri": "6.2.0",
         "url": "0.11.0",
         "video-name-parser": "1.4.6",
-        "vtt.js": "github:jaruba/vtt.js#e4f5f5603730866bacb174a93f51b734c9f29e6a"
+        "vtt.js": "github:jaruba/vtt.js#84d33d157848407d790d78423dacc41a096294f0"
     },
     "devDependencies": {
         "eslint": "7.32.0"


### PR DESCRIPTION
There was a warning given when parsing cues, this was caused by a bug and it was clogging the main thread with thousands of warnings when debugging