### PR TITLE
fix: workaround to make Airplay work on Safari

### DIFF
--- a/src/HTMLVideo/HTMLVideo.js
+++ b/src/HTMLVideo/HTMLVideo.js
@@ -589,8 +589,8 @@ function HTMLVideo(options) {
                 videoElement.load();
                 videoElement.currentTime = 0;
                 Array.from(videoElement.children || []).forEach(function(child) {
-                    if (child && child.dataset && child.dataset.id === 'original-stream' && child.remove) {
-                        child.remove();
+                    if (child && child.dataset && child.dataset.id === 'original-stream') {
+                        videoElement.removeChild(child);
                     }
                 });
                 onPropChanged('stream');

--- a/src/HTMLVideo/HTMLVideo.js
+++ b/src/HTMLVideo/HTMLVideo.js
@@ -543,6 +543,7 @@ function HTMLVideo(options) {
                                 function attachOriginalSource() {
                                     var source = document.createElement('source');
                                     source.src = stream.url;
+                                    source.dataset.id = 'original-stream';
                                     videoElement.appendChild(source);
                                     videoElement.disableRemotePlayback = false;
 
@@ -587,6 +588,11 @@ function HTMLVideo(options) {
                 videoElement.removeAttribute('src');
                 videoElement.load();
                 videoElement.currentTime = 0;
+                Array.from(videoElement.children || []).forEach(function(child) {
+                    if (child && child.dataset && child.dataset.id === 'original-stream' && child.remove) {
+                        child.remove();
+                    }
+                });
                 onPropChanged('stream');
                 onPropChanged('loaded');
                 onPropChanged('paused');


### PR DESCRIPTION
Implemented the suggested workaround from [this comment](https://github.com/video-dev/hls.js/issues/5989#issuecomment-1825916766) to make Airplay work in Safari.

For some reason, audio doesn't play on Airplay on my TV, but I think this should probably be handled on the streaming server.
Previously, using Airplay didn't work at all, so this PR is still an improvement since the video is now displayed on the target device properly.

Airplay support was added to the player of Stremio Web in this PR: https://github.com/Stremio/stremio-web/pull/629