### PR TITLE
Streaming server proxy

### DIFF
--- a/src/withStreamingServer/convertStream.js
+++ b/src/withStreamingServer/convertStream.js
@@ -1,7 +1,21 @@
+var url = require('url');
 var magnet = require('magnet-uri');
 var createTorrent = require('./createTorrent');
 
-function convertStream(streamingServerURL, stream, seriesInfo) {
+function buildProxyUrl(streamingServerURL, streamURL, requestHeaders, responseHeaders) {
+    var parsedStreamURL = new URL(streamURL);
+    var proxyOptions = new URLSearchParams();
+    proxyOptions.set('d', parsedStreamURL.origin);
+    Object.entries(requestHeaders).forEach(function([header, value]) {
+        proxyOptions.append('h', header + ':' + value);
+    });
+    Object.entries(responseHeaders).forEach(function([header, value]) {
+        proxyOptions.append('r', header + ':' + value);
+    });
+    return url.resolve(streamingServerURL, '/proxy/' + proxyOptions.toString() + parsedStreamURL.pathname) + parsedStreamURL.search;
+}
+
+function convertStream(streamingServerURL, stream, seriesInfo, streamingServerSettings) {
     return new Promise(function(resolve, reject) {
         if (typeof stream.url === 'string') {
             if (stream.url.indexOf('magnet:') === 0) {
@@ -30,7 +44,15 @@ function convertStream(streamingServerURL, stream, seriesInfo) {
                         reject(error);
                     });
             } else {
-                resolve({ url: stream.url });
+                var proxyStreamsEnabled = streamingServerSettings && streamingServerSettings.proxyStreamsEnabled;
+                var proxyHeaders = stream.behaviorHints && stream.behaviorHints.proxyHeaders;
+                if (proxyStreamsEnabled || proxyHeaders) {
+                    var requestHeaders = proxyHeaders && proxyHeaders.request ? proxyHeaders.request : {};
+                    var responseHeaders = proxyHeaders && proxyHeaders.response ? proxyHeaders.response : {};
+                    resolve({ url: buildProxyUrl(streamingServerURL, stream.url, requestHeaders, responseHeaders) });
+                } else {
+                    resolve({ url: stream.url });
+                }
             }
 
             return;

--- a/src/withStreamingServer/convertStream.js
+++ b/src/withStreamingServer/convertStream.js
@@ -6,11 +6,11 @@ function buildProxyUrl(streamingServerURL, streamURL, requestHeaders, responseHe
     var parsedStreamURL = new URL(streamURL);
     var proxyOptions = new URLSearchParams();
     proxyOptions.set('d', parsedStreamURL.origin);
-    Object.entries(requestHeaders).forEach(function([header, value]) {
-        proxyOptions.append('h', header + ':' + value);
+    Object.entries(requestHeaders).forEach(function(entry) {
+        proxyOptions.append('h', entry[0] + ':' + entry[1]);
     });
-    Object.entries(responseHeaders).forEach(function([header, value]) {
-        proxyOptions.append('r', header + ':' + value);
+    Object.entries(responseHeaders).forEach(function(entry) {
+        proxyOptions.append('r', entry[0] + ':' + entry[1]);
     });
     return url.resolve(streamingServerURL, '/proxy/' + proxyOptions.toString() + parsedStreamURL.pathname) + parsedStreamURL.search;
 }

--- a/src/withStreamingServer/withStreamingServer.js
+++ b/src/withStreamingServer/withStreamingServer.js
@@ -104,7 +104,7 @@ function withStreamingServer(Video) {
                         video.dispatch({ type: 'command', commandName: 'unload' });
                         loadArgs = commandArgs;
                         onPropChanged('stream');
-                        convertStream(commandArgs.streamingServerURL, commandArgs.stream, commandArgs.seriesInfo, convertStream.streamingServerSettings)
+                        convertStream(commandArgs.streamingServerURL, commandArgs.stream, commandArgs.seriesInfo, commandArgs.streamingServerSettings)
                             .then(function(result) {
                                 var mediaURL = result.url;
                                 var infoHash = result.infoHash;

--- a/src/withStreamingServer/withStreamingServer.js
+++ b/src/withStreamingServer/withStreamingServer.js
@@ -104,7 +104,7 @@ function withStreamingServer(Video) {
                         video.dispatch({ type: 'command', commandName: 'unload' });
                         loadArgs = commandArgs;
                         onPropChanged('stream');
-                        convertStream(commandArgs.streamingServerURL, commandArgs.stream, commandArgs.seriesInfo)
+                        convertStream(commandArgs.streamingServerURL, commandArgs.stream, commandArgs.seriesInfo, convertStream.streamingServerSettings)
                             .then(function(result) {
                                 var mediaURL = result.url;
                                 var infoHash = result.infoHash;


### PR DESCRIPTION
With this PR every url stream that is not a magnet link is proxied through streaming server if the stream contains `proxyHeaders` behavior hint.
Additionally the stream is also proxied if `proxyStreamEnabled` setting in enabled in the streaming server.