### PR TITLE
Background transparent fix

### DIFF
--- a/src/ShellVideo/ShellVideo.js
+++ b/src/ShellVideo/ShellVideo.js
@@ -347,10 +347,10 @@ function ShellVideo(options) {
                         var windowRenderer = navigator.platform === 'Win32' ? 'direct3d' : 'opengl';
                         var videoOutput = options.mpvSeparateWindow ? windowRenderer : 'opengl-cb';
                         var separateWindow = options.mpvSeparateWindow ? 'yes' : 'no';
-                        ipc.send('mpv-set-prop', ['vo', videoOutput]);
+                        ipc.send('mpv-set-prop', ['vo', window.chrome && window.chrome.webview ? 'gpu-next' : videoOutput]);
                         ipc.send('mpv-set-prop', ['osc', separateWindow]);
-                        ipc.send('mpv-set-prop', ['input-defalt-bindings', separateWindow]);
-                        ipc.send('mpv-set-prop', ['input-vo-keyboard', separateWindow]);
+                        ipc.send('mpv-set-prop', ['input-default-bindings', window.chrome && window.chrome.webview ? 'yes' : separateWindow]);
+                        ipc.send('mpv-set-prop', ['input-vo-keyboard', window.chrome && window.chrome.webview ? 'yes' : separateWindow]);
 
                         var startAt = Math.floor(parseInt(commandArgs.time, 10) / 1000) || 0;
                         if (startAt !== 0) {

--- a/src/ShellVideo/ShellVideo.js
+++ b/src/ShellVideo/ShellVideo.js
@@ -123,7 +123,6 @@ function ShellVideo(options) {
                 break;
             }
             case 'duration': {
-                setBackground(false);
                 var intDuration = args.data | 0;
                 // Accumulate average duration over time. if it is greater than minClipDuration
                 // and equal to the currently reported duration, it is returned as video length.
@@ -138,7 +137,10 @@ function ShellVideo(options) {
                 // which is around 34 years of playback time.
                 avgDuration = avgDuration ? (avgDuration + intDuration) >> 1 : intDuration;
                 props.loaded = intDuration > 0;
-                if(props.loaded) onPropChanged('loaded');
+                if(props.loaded) {
+                    setBackground(false);
+                    onPropChanged('loaded');
+                }
                 break;
             }
             case 'time-pos': {

--- a/src/ShellVideo/ShellVideo.js
+++ b/src/ShellVideo/ShellVideo.js
@@ -198,8 +198,8 @@ function ShellVideo(options) {
                         return {
                             id: 'EMBEDDED_' + x.id,
                             lang: x.lang === undefined ? 'Other Tracks' : x.lang,
-                            label: x.title.replace('External', '') || x.lang || '',
-                            origin: x.title.includes("External") ? 'External' : 'EMBEDDED',
+                            label: x.title.includes("External") ? x.lang : (x.title || x.lang || ''),
+                            origin: x.title.includes("External") ? x.title.replace('External', '') : 'EMBEDDED',
                             embedded: true,
                             mode: x.id === props.sid ? 'showing' : 'disabled',
                         };

--- a/src/ShellVideo/ShellVideo.js
+++ b/src/ShellVideo/ShellVideo.js
@@ -342,15 +342,13 @@ function ShellVideo(options) {
                         // opengl-cb is an alias for the new name "libmpv", as shown in mpv's video/out/vo.c aliases
                         // opengl is an alias for the new name "gpu"
                         // When on Windows we use d3d for the rendering in separate window
-                        if (window.qt && (!window.chrome || !window.chrome.webview)) {
-                            var windowRenderer = navigator.platform === 'Win32' ? 'direct3d' : 'opengl';
-                            var videoOutput = options.mpvSeparateWindow ? windowRenderer : 'opengl-cb';
-                            var separateWindow = options.mpvSeparateWindow ? 'yes' : 'no';
-                            ipc.send('mpv-set-prop', ['vo', videoOutput]);
-                            ipc.send('mpv-set-prop', ['osc', separateWindow]);
-                            ipc.send('mpv-set-prop', ['input-defalt-bindings', separateWindow]);
-                            ipc.send('mpv-set-prop', ['input-vo-keyboard', separateWindow]);
-                        }
+                        var windowRenderer = navigator.platform === 'Win32' ? 'direct3d' : 'opengl';
+                        var videoOutput = options.mpvSeparateWindow ? windowRenderer : 'opengl-cb';
+                        var separateWindow = options.mpvSeparateWindow ? 'yes' : 'no';
+                        ipc.send('mpv-set-prop', ['vo', videoOutput]);
+                        ipc.send('mpv-set-prop', ['osc', separateWindow]);
+                        ipc.send('mpv-set-prop', ['input-defalt-bindings', separateWindow]);
+                        ipc.send('mpv-set-prop', ['input-vo-keyboard', separateWindow]);
 
                         var startAt = Math.floor(parseInt(commandArgs.time, 10) / 1000) || 0;
                         if (startAt !== 0) {

--- a/src/ShellVideo/ShellVideo.js
+++ b/src/ShellVideo/ShellVideo.js
@@ -198,8 +198,8 @@ function ShellVideo(options) {
                         return {
                             id: 'EMBEDDED_' + x.id,
                             lang: x.lang === undefined ? 'Other Tracks' : x.lang,
-                            label: x.title || x.lang || '',
-                            origin: 'EMBEDDED',
+                            label: x.title.replace('External', '') || x.lang || '',
+                            origin: x.title.includes("External") ? 'External' : 'EMBEDDED',
                             embedded: true,
                             mode: x.id === props.sid ? 'showing' : 'disabled',
                         };

--- a/src/ShellVideo/ShellVideo.js
+++ b/src/ShellVideo/ShellVideo.js
@@ -20,6 +20,7 @@ var stremioToMPVProps = {
     'subtitlesTracks': 'subtitlesTracks',
     'selectedSubtitlesTrackId': 'sid',
     'subtitlesSize': 'sub-scale',
+    'subtitlesOffset': 'sub-pos',
     'subtitlesTextColor': 'sub-color',
     'subtitlesBackgroundColor': 'sub-back-color',
     'subtitlesOutlineColor': 'sub-border-color',
@@ -146,6 +147,10 @@ function ShellVideo(options) {
             }
             case 'sub-scale': {
                 props[args.name] = Math.round(args.data / SUBS_SCALE_FACTOR);
+                break;
+            }
+            case 'sub-pos': {
+                props[args.name] = 100 - args.data;
                 break;
             }
             case 'paused-for-cache':
@@ -305,7 +310,7 @@ function ShellVideo(options) {
                 break;
             }
             case 'subtitlesOffset': {
-                ipc.send('mpv-set-prop', [stremioToMPVProps[propName], propValue]);
+                ipc.send('mpv-set-prop', [stremioToMPVProps[propName], 100 - propValue]);
                 break;
             }
             case 'subtitlesTextColor':

--- a/src/ShellVideo/ShellVideo.js
+++ b/src/ShellVideo/ShellVideo.js
@@ -115,7 +115,6 @@ function ShellVideo(options) {
     ipc.on('mpv-prop-change', function(args) {
         switch (args.name) {
             case 'mpv-version':
-                setBackground(false);
                 resolveMPVVersion(args.data);
                 props[args.name] = logProp(args);
                 break;
@@ -124,6 +123,7 @@ function ShellVideo(options) {
                 break;
             }
             case 'duration': {
+                setBackground(false);
                 var intDuration = args.data | 0;
                 // Accumulate average duration over time. if it is greater than minClipDuration
                 // and equal to the currently reported duration, it is returned as video length.

--- a/src/ShellVideo/ShellVideo.js
+++ b/src/ShellVideo/ShellVideo.js
@@ -337,13 +337,15 @@ function ShellVideo(options) {
                         // opengl-cb is an alias for the new name "libmpv", as shown in mpv's video/out/vo.c aliases
                         // opengl is an alias for the new name "gpu"
                         // When on Windows we use d3d for the rendering in separate window
-                        var windowRenderer = navigator.platform === 'Win32' ? 'direct3d' : 'opengl';
-                        var videoOutput = options.mpvSeparateWindow ? windowRenderer : 'opengl-cb';
-                        var separateWindow = options.mpvSeparateWindow ? 'yes' : 'no';
-                        ipc.send('mpv-set-prop', ['vo', videoOutput]);
-                        ipc.send('mpv-set-prop', ['osc', separateWindow]);
-                        ipc.send('mpv-set-prop', ['input-defalt-bindings', separateWindow]);
-                        ipc.send('mpv-set-prop', ['input-vo-keyboard', separateWindow]);
+                        if (window.qt && (!window.chrome || !window.chrome.webview)) {
+                            var windowRenderer = navigator.platform === 'Win32' ? 'direct3d' : 'opengl';
+                            var videoOutput = options.mpvSeparateWindow ? windowRenderer : 'opengl-cb';
+                            var separateWindow = options.mpvSeparateWindow ? 'yes' : 'no';
+                            ipc.send('mpv-set-prop', ['vo', videoOutput]);
+                            ipc.send('mpv-set-prop', ['osc', separateWindow]);
+                            ipc.send('mpv-set-prop', ['input-defalt-bindings', separateWindow]);
+                            ipc.send('mpv-set-prop', ['input-vo-keyboard', separateWindow]);
+                        }
 
                         var startAt = Math.floor(parseInt(commandArgs.time, 10) / 1000) || 0;
                         if (startAt !== 0) {

--- a/src/ShellVideo/ShellVideo.js
+++ b/src/ShellVideo/ShellVideo.js
@@ -21,6 +21,7 @@ var stremioToMPVProps = {
     'selectedSubtitlesTrackId': 'sid',
     'subtitlesSize': 'sub-scale',
     'subtitlesOffset': 'sub-pos',
+    'subtitlesDelay': 'sub-delay',
     'subtitlesTextColor': 'sub-color',
     'subtitlesBackgroundColor': 'sub-back-color',
     'subtitlesOutlineColor': 'sub-border-color',
@@ -78,6 +79,7 @@ function ShellVideo(options) {
     ipc.send('mpv-observe-prop', 'sid');
     ipc.send('mpv-observe-prop', 'sub-scale');
     ipc.send('mpv-observe-prop', 'sub-pos');
+    ipc.send('mpv-observe-prop', 'sub-delay');
     ipc.send('mpv-observe-prop', 'speed');
 
     ipc.send('mpv-observe-prop', 'mpv-version');
@@ -153,6 +155,10 @@ function ShellVideo(options) {
             }
             case 'sub-pos': {
                 props[args.name] = 100 - args.data;
+                break;
+            }
+            case 'sub-delay': {
+                props[args.name] = Math.round(args.data*1000);
                 break;
             }
             case 'paused-for-cache':
@@ -309,6 +315,10 @@ function ShellVideo(options) {
             }
             case 'subtitlesSize': {
                 ipc.send('mpv-set-prop', [stremioToMPVProps[propName], propValue * SUBS_SCALE_FACTOR]);
+                break;
+            }
+            case 'subtitlesDelay': {
+                ipc.send('mpv-set-prop', [stremioToMPVProps[propName], propValue]);
                 break;
             }
             case 'subtitlesOffset': {

--- a/src/ShellVideo/ShellVideo.js
+++ b/src/ShellVideo/ShellVideo.js
@@ -114,6 +114,7 @@ function ShellVideo(options) {
     ipc.on('mpv-prop-change', function(args) {
         switch (args.name) {
             case 'mpv-version':
+                setBackground(false);
                 resolveMPVVersion(args.data);
                 props[args.name] = logProp(args);
                 break;
@@ -122,7 +123,6 @@ function ShellVideo(options) {
                 break;
             }
             case 'duration': {
-                setBackground(false);
                 var intDuration = args.data | 0;
                 // Accumulate average duration over time. if it is greater than minClipDuration
                 // and equal to the currently reported duration, it is returned as video length.

--- a/src/ShellVideo/ShellVideo.js
+++ b/src/ShellVideo/ShellVideo.js
@@ -189,8 +189,8 @@ function ShellVideo(options) {
                     .map(function(x, index) {
                         return {
                             id: 'EMBEDDED_' + x.id,
-                            lang: x.lang === undefined ? 'Track ' + (index + 1) : x.lang,
-                            label: x.title === undefined || x.lang === undefined ? '' : x.title || x.lang,
+                            lang: x.lang === undefined ? 'Other Tracks' : x.lang,
+                            label: x.title || x.lang || '',
                             origin: 'EMBEDDED',
                             embedded: true,
                             mode: x.id === props.sid ? 'showing' : 'disabled',


### PR DESCRIPTION
- Fix for background being transparent after shell video was unmounted
- Moved setBackground to mpv-version
- This ensures it only triggers once on start of player. It seems like duration also triggers onEnd (unmount) of player causing background to be set back to visible false. See logs below:



Before - `"duration"` is triggered after player unmount still setting background as transparent:
![image](https://github.com/user-attachments/assets/36a09c8a-d9f8-43d6-9993-d5e6a9546abb)


After - Sets background visible false on `"mpv-version"` which is always triggered **only** once on start of playback:
![image](https://github.com/user-attachments/assets/9699c294-8a60-4068-bb8e-7b06616b92bb)

(Playback ended after error)