### PR TITLE
Fix tizen 5

### DIFF
--- a/src/StremioVideo/StremioVideo.js
+++ b/src/StremioVideo/StremioVideo.js
@@ -2,6 +2,7 @@ var EventEmitter = require('eventemitter3');
 var cloneDeep = require('lodash.clonedeep');
 var deepFreeze = require('deep-freeze');
 var selectVideoImplementation = require('./selectVideoImplementation');
+var platform = require('../platform');
 var ERROR = require('../error');
 
 function StremioVideo() {
@@ -25,6 +26,9 @@ function StremioVideo() {
             action = deepFreeze(cloneDeep(action));
             options = options || {};
             if (action.type === 'command' && action.commandName === 'load' && action.commandArgs) {
+                if (action.commandArgs.platform) {
+                    platform.set(action.commandArgs.platform);
+                }
                 var Video = selectVideoImplementation(action.commandArgs, options);
                 if (video !== null && video.constructor !== Video) {
                     video.dispatch({ type: 'command', commandName: 'destroy' });

--- a/src/TizenVideo/TizenVideo.js
+++ b/src/TizenVideo/TizenVideo.js
@@ -631,10 +631,12 @@ function TizenVideo(options) {
                     }
                     onPropChanged('buffering');
 
-                    var TIZEN_MATCHES = navigator.userAgent.match(/Tizen (\d+\.\d+)/i)
+                    var tizenVersion = false;
+
+                    var TIZEN_MATCHES = navigator.userAgent.match(/Tizen (\d+\.\d+)/i);
 
                     if (TIZEN_MATCHES && TIZEN_MATCHES[1]) {
-                        tizenVersion = parseFloat(TIZEN_MATCHES[1])
+                        tizenVersion = parseFloat(TIZEN_MATCHES[1]);
                     }
 
                     if (!tizenVersion || tizenVersion >= 6) {

--- a/src/TizenVideo/TizenVideo.js
+++ b/src/TizenVideo/TizenVideo.js
@@ -631,11 +631,11 @@ function TizenVideo(options) {
                     }
                     onPropChanged('buffering');
 
-                    var tizenVersion = false;
+                    var TIZEN_MATCHES = navigator.userAgent.match(/Tizen (\d+\.\d+)/i)
 
-                    try {
-                        tizenVersion = parseFloat(global.tizen.systeminfo.getCapability('http://tizen.org/feature/platform.version'));
-                    } catch(e) {}
+                    if (TIZEN_MATCHES && TIZEN_MATCHES[1]) {
+                        tizenVersion = parseFloat(TIZEN_MATCHES[1])
+                    }
 
                     if (!tizenVersion || tizenVersion >= 6) {
                         retrieveExtendedTracks();

--- a/src/platform.js
+++ b/src/platform.js
@@ -1,0 +1,6 @@
+var platform = null;
+
+module.exports = {
+    set: function(val) { platform = val; },
+    get: function() { return platform; }
+};

--- a/src/supportsTranscoding.js
+++ b/src/supportsTranscoding.js
@@ -1,5 +1,7 @@
+var platform = require('./platform');
+
 function supportsTranscoding() {
-    if (typeof window.tizen !== 'undefined' || typeof window.webOS !== 'undefined' || typeof window.qt !== 'undefined') {
+    if (['Tizen', 'webOS'].includes(platform.get()) || typeof window.qt !== 'undefined') {
         return Promise.resolve(false);
     }
     return Promise.resolve(true);

--- a/src/supportsTranscoding.js
+++ b/src/supportsTranscoding.js
@@ -1,5 +1,5 @@
 function supportsTranscoding() {
-    if (typeof global.tizen !== 'undefined' || typeof global.webOS !== 'undefined' || typeof window.qt !== 'undefined') {
+    if (typeof window.tizen !== 'undefined' || typeof window.webOS !== 'undefined' || typeof window.qt !== 'undefined') {
         return Promise.resolve(false);
     }
     return Promise.resolve(true);


### PR DESCRIPTION
The logic in the try {} catch(e) {} was failing because global.tizen is undefined on Tizen 5 in our context