### PR TITLE
Shell v5 - Fix Typo in mpv-set-prop

### DIFF
--- a/src/ShellVideo/ShellVideo.js
+++ b/src/ShellVideo/ShellVideo.js
@@ -342,7 +342,7 @@ function ShellVideo(options) {
                         var separateWindow = options.mpvSeparateWindow ? 'yes' : 'no';
                         ipc.send('mpv-set-prop', ['vo', videoOutput]);
                         ipc.send('mpv-set-prop', ['osc', separateWindow]);
-                        ipc.send('mpv-set-prop', ['input-defalt-bindings', separateWindow]);
+                        ipc.send('mpv-set-prop', ['input-default-bindings', separateWindow]);
                         ipc.send('mpv-set-prop', ['input-vo-keyboard', separateWindow]);
 
                         var startAt = Math.floor(parseInt(commandArgs.time, 10) / 1000) || 0;


### PR DESCRIPTION
This is one of multiple PRs that are split from https://github.com/Stremio/stremio-video/pull/92

More details found at the parent PR