### PR TITLE
fix: better outline with textShadow for subtitles

### DIFF
--- a/src/HTMLVideo/HTMLVideo.js
+++ b/src/HTMLVideo/HTMLVideo.js
@@ -17,7 +17,7 @@ function HTMLVideo(options) {
 
     var styleElement = document.createElement('style');
     containerElement.appendChild(styleElement);
-    styleElement.sheet.insertRule('video::cue { font-size: 4vmin; color: rgb(255, 255, 255); background-color: rgba(0, 0, 0, 0); text-shadow: rgb(34, 34, 34) 1px 1px 0.1em; }');
+    styleElement.sheet.insertRule('video::cue { font-size: 4vmin; color: rgb(255, 255, 255); background-color: rgba(0, 0, 0, 0); text-shadow: -0.15rem -0.15rem 0.15rem rgb(34, 34, 34), 0px -0.15rem 0.15rem rgb(34, 34, 34), 0.15rem -0.15rem 0.15rem rgb(34, 34, 34), -0.15rem 0px 0.15rem rgb(34, 34, 34), 0.15rem 0px 0.15rem rgb(34, 34, 34), -0.15rem 0.15rem 0.15rem rgb(34, 34, 34), 0px 0.15rem 0.15rem rgb(34, 34, 34), 0.15rem 0.15rem 0.15rem rgb(34, 34, 34); }');
     var videoElement = document.createElement('video');
     videoElement.style.width = '100%';
     videoElement.style.height = '100%';
@@ -458,7 +458,7 @@ function HTMLVideo(options) {
                 if (typeof propValue === 'string') {
                     try {
                         var outlineColor = Color(propValue).rgb().string();
-                        styleElement.sheet.cssRules[0].style.textShadow = '-0.05em -0.05em 0.05em ' + outlineColor + ', 0px -0.05em 0.05em ' + outlineColor + ', 0.05em -0.05em 0.05em ' + outlineColor + ', -0.05em 0px 0.05em ' + outlineColor + ', 0.05em 0px 0.05em ' + outlineColor + ', -0.05em 0.05em 0.05em ' + outlineColor + ', 0px 0.05em 0.05em ' + outlineColor + ', 0.05em 0.05em 0.05em ' + outlineColor;
+                        styleElement.sheet.cssRules[0].style.textShadow = '-0.15rem -0.15rem 0.15rem ' + outlineColor + ', 0px -0.15rem 0.15rem ' + outlineColor + ', 0.15rem -0.15rem 0.15rem ' + outlineColor + ', -0.15rem 0px 0.15rem ' + outlineColor + ', 0.15rem 0px 0.15rem ' + outlineColor + ', -0.15rem 0.15rem 0.15rem ' + outlineColor + ', 0px 0.15rem 0.15rem ' + outlineColor + ', 0.15rem 0.15rem 0.15rem ' + outlineColor;
                     } catch (error) {
                         // eslint-disable-next-line no-console
                         console.error('HTMLVideo', error);

--- a/src/HTMLVideo/HTMLVideo.js
+++ b/src/HTMLVideo/HTMLVideo.js
@@ -457,7 +457,8 @@ function HTMLVideo(options) {
             case 'subtitlesOutlineColor': {
                 if (typeof propValue === 'string') {
                     try {
-                        styleElement.sheet.cssRules[0].style.textShadow = Color(propValue).rgb().string() + ' 1px 1px 0.1em';
+                        var outlineColor = Color(propValue).rgb().string();
+                        styleElement.sheet.cssRules[0].style.textShadow = '-0.05em -0.05em 0.05em ' + outlineColor + ', 0px -0.05em 0.05em ' + outlineColor + ', 0.05em -0.05em 0.05em ' + outlineColor + ', -0.05em 0px 0.05em ' + outlineColor + ', 0.05em 0px 0.05em ' + outlineColor + ', -0.05em 0.05em 0.05em ' + outlineColor + ', 0px 0.05em 0.05em ' + outlineColor + ', 0.05em 0.05em 0.05em ' + outlineColor;
                     } catch (error) {
                         // eslint-disable-next-line no-console
                         console.error('HTMLVideo', error);

--- a/src/withHTMLSubtitles/withHTMLSubtitles.js
+++ b/src/withHTMLSubtitles/withHTMLSubtitles.js
@@ -51,9 +51,19 @@ function withHTMLSubtitles(Video) {
         var size = 100;
         var offset = 0;
         var textColor = 'rgb(255, 255, 255)';
-        var backgroundColor = 'rgba(0, 0, 0, 0)';
+
+        var subsBgStyle = 1;
+        // Calculate the #c010r. First slice the # and cast to int
+        var intColor = parseInt(outlineColor.slice(1), 16);
+        var backgroundColor = 'rgba(' +
+            ((intColor >> 16) & 255) + ', ' + // Red
+            ((intColor >> 8) & 255) + ', ' + // Green
+            (intColor & 255) + ', ' + // Blue
+            subsBgStyle + ')'; // Alpha
         var outlineColor = 'rgb(34, 34, 34)';
+
         var opacity = 1;
+
         var observedProps = {
             extraSubtitlesTracks: false,
             selectedExtraSubtitlesTrackId: false,
@@ -85,7 +95,7 @@ function withHTMLSubtitles(Video) {
                 cueNode.style.fontSize = Math.floor((size / 25) * fontSizeMultiplier) + 'vmin';
                 cueNode.style.color = textColor;
                 cueNode.style.backgroundColor = backgroundColor;
-                cueNode.style.textShadow = '1px 1px 0.1em ' + outlineColor;
+                cueNode.style.textShadow = '-0.05em -0.05em 0.05em ' + outlineColor + ', 0px -0.05em 0.05em ' + outlineColor + ', 0.05em -0.05em 0.05em ' + outlineColor + ', -0.05em 0px 0.05em ' + outlineColor + ', 0.05em 0px 0.05em ' + outlineColor + ', -0.05em 0.05em 0.05em ' + outlineColor + ', 0px 0.05em 0.05em ' + outlineColor + ', 0.05em 0.05em 0.05em ' + outlineColor;
                 subtitlesElement.appendChild(cueNode);
                 subtitlesElement.appendChild(document.createElement('br'));
             });

--- a/src/withHTMLSubtitles/withHTMLSubtitles.js
+++ b/src/withHTMLSubtitles/withHTMLSubtitles.js
@@ -52,15 +52,8 @@ function withHTMLSubtitles(Video) {
         var offset = 0;
         var textColor = 'rgb(255, 255, 255)';
 
-        var subsBgStyle = 1;
         var outlineColor = 'rgb(34, 34, 34)';
-        // Calculate the #c010r. First slice the # and cast to int
-        var intColor = parseInt(outlineColor.slice(1), 16);
-        var backgroundColor = 'rgba(' +
-            ((intColor >> 16) & 255) + ', ' + // Red
-            ((intColor >> 8) & 255) + ', ' + // Green
-            (intColor & 255) + ', ' + // Blue
-            subsBgStyle + ')'; // Alpha
+        var backgroundColor = outlineColor;
 
         var opacity = 1;
 

--- a/src/withHTMLSubtitles/withHTMLSubtitles.js
+++ b/src/withHTMLSubtitles/withHTMLSubtitles.js
@@ -51,10 +51,8 @@ function withHTMLSubtitles(Video) {
         var size = 100;
         var offset = 0;
         var textColor = 'rgb(255, 255, 255)';
-
+        var backgroundColor = 'rgba(0, 0, 0, 0)';
         var outlineColor = 'rgb(34, 34, 34)';
-        var backgroundColor = outlineColor;
-
         var opacity = 1;
 
         var observedProps = {

--- a/src/withHTMLSubtitles/withHTMLSubtitles.js
+++ b/src/withHTMLSubtitles/withHTMLSubtitles.js
@@ -95,7 +95,7 @@ function withHTMLSubtitles(Video) {
                 cueNode.style.fontSize = Math.floor((size / 25) * fontSizeMultiplier) + 'vmin';
                 cueNode.style.color = textColor;
                 cueNode.style.backgroundColor = backgroundColor;
-                cueNode.style.textShadow = '-0.05em -0.05em 0.05em ' + outlineColor + ', 0px -0.05em 0.05em ' + outlineColor + ', 0.05em -0.05em 0.05em ' + outlineColor + ', -0.05em 0px 0.05em ' + outlineColor + ', 0.05em 0px 0.05em ' + outlineColor + ', -0.05em 0.05em 0.05em ' + outlineColor + ', 0px 0.05em 0.05em ' + outlineColor + ', 0.05em 0.05em 0.05em ' + outlineColor;
+                cueNode.style.textShadow = '-0.15rem -0.15rem 0.15rem ' + outlineColor + ', 0px -0.15rem 0.15rem ' + outlineColor + ', 0.15rem -0.15rem 0.15rem ' + outlineColor + ', -0.15rem 0px 0.15rem ' + outlineColor + ', 0.15rem 0px 0.15rem ' + outlineColor + ', -0.15rem 0.15rem 0.15rem ' + outlineColor + ', 0px 0.15rem 0.15rem ' + outlineColor + ', 0.15rem 0.15rem 0.15rem ' + outlineColor;
                 subtitlesElement.appendChild(cueNode);
                 subtitlesElement.appendChild(document.createElement('br'));
             });

--- a/src/withHTMLSubtitles/withHTMLSubtitles.js
+++ b/src/withHTMLSubtitles/withHTMLSubtitles.js
@@ -53,6 +53,7 @@ function withHTMLSubtitles(Video) {
         var textColor = 'rgb(255, 255, 255)';
 
         var subsBgStyle = 1;
+        var outlineColor = 'rgb(34, 34, 34)';
         // Calculate the #c010r. First slice the # and cast to int
         var intColor = parseInt(outlineColor.slice(1), 16);
         var backgroundColor = 'rgba(' +
@@ -60,7 +61,6 @@ function withHTMLSubtitles(Video) {
             ((intColor >> 8) & 255) + ', ' + // Green
             (intColor & 255) + ', ' + // Blue
             subsBgStyle + ')'; // Alpha
-        var outlineColor = 'rgb(34, 34, 34)';
 
         var opacity = 1;
 


### PR DESCRIPTION
text shadow style has been taken from Stremio 4  and applied to both Html subtitles (external subtitles) and embedded.


### Embedded subtitles (after)
![image](https://github.com/user-attachments/assets/29d9ad3e-090f-48f4-b0bb-dbfbba2fac67)

### External subtitles (after)

![image](https://github.com/user-attachments/assets/385a7020-8ac4-4b93-85cd-24bf1c9147fe)
