### PR TITLE
WebOS: Fix override of saved audio track id

### DIFF
--- a/src/WebOsVideo/WebOsVideo.js
+++ b/src/WebOsVideo/WebOsVideo.js
@@ -398,7 +398,9 @@ function WebOsVideo(options) {
                             mode: audioTrackId === currentAudioTrack ? 'showing' : 'disabled',
                         });
                     });
-                    currentAudioTrack = 'EMBEDDED_0';
+                    if (!currentAudioTrack) {
+                        currentAudioTrack = 'EMBEDDED_0';
+                    }
                     onPropChanged('audioTracks');
                     onPropChanged('selectedAudioTrackId');
                 }


### PR DESCRIPTION
This change fixes the issue of the saved audio track id being overridden to `EMBEDDED_0`.