### PR TITLE
Refactor: Optimise subtitles rendering

### DIFF
--- a/src/withHTMLSubtitles/subtitlesRenderer.js
+++ b/src/withHTMLSubtitles/subtitlesRenderer.js
@@ -1,9 +1,7 @@
 var VTTJS = require('vtt.js');
-var binarySearchUpperBound = require('./binarySearchUpperBound');
 
-function render(cuesByTime, time) {
+function render(cuesByTime, timeIndex) {
     var nodes = [];
-    var timeIndex = binarySearchUpperBound(cuesByTime.times, time);
     if (timeIndex !== -1) {
         var cuesForTime = cuesByTime[cuesByTime.times[timeIndex]];
         for (var i = 0; i < cuesForTime.length; i++) {

--- a/src/withHTMLSubtitles/withHTMLSubtitles.js
+++ b/src/withHTMLSubtitles/withHTMLSubtitles.js
@@ -40,8 +40,11 @@ function withHTMLSubtitles(Video) {
         containerElement.appendChild(subtitlesElement);
 
         var videoState = {
-            time: null
+            time: null,
+            paused: false,
+            lastSyncAt: null
         };
+        var rafId = null;
         var cuesByTime = null;
         var events = new EventEmitter();
         var destroyed = false;
@@ -67,18 +70,43 @@ function withHTMLSubtitles(Video) {
             extraSubtitlesOpacity: false
         };
 
+        function getCurrentTime() {
+            if (videoState.time === null || !isFinite(videoState.time)) {
+                return null;
+            }
+            if (videoState.paused || videoState.lastSyncAt === null) {
+                return videoState.time;
+            }
+            return videoState.time + (Date.now() - videoState.lastSyncAt);
+        }
+        function startRenderLoop() {
+            if (rafId !== null) {
+                return;
+            }
+            (function loop() {
+                renderSubtitles();
+                rafId = requestAnimationFrame(loop);
+            })();
+        }
+        function stopRenderLoop() {
+            if (rafId !== null) {
+                cancelAnimationFrame(rafId);
+                rafId = null;
+            }
+        }
         function renderSubtitles() {
             while (subtitlesElement.hasChildNodes()) {
                 subtitlesElement.removeChild(subtitlesElement.lastChild);
             }
 
-            if (cuesByTime === null || videoState.time === null || !isFinite(videoState.time)) {
+            var time = getCurrentTime();
+            if (cuesByTime === null || time === null) {
                 return;
             }
 
             subtitlesElement.style.bottom = offset + '%';
             subtitlesElement.style.opacity = opacity;
-            subtitlesRenderer.render(cuesByTime, videoState.time - delay).forEach(function(cueNode) {
+            subtitlesRenderer.render(cuesByTime, time - delay).forEach(function(cueNode) {
                 cueNode.style.display = 'inline-block';
                 cueNode.style.padding = '0.2em';
                 cueNode.style.whiteSpace = 'pre-wrap';
@@ -101,7 +129,17 @@ function withHTMLSubtitles(Video) {
             switch (propName) {
                 case 'time': {
                     videoState.time = propValue;
-                    renderSubtitles();
+                    videoState.lastSyncAt = Date.now();
+                    break;
+                }
+                case 'paused': {
+                    if (propValue && !videoState.paused && videoState.lastSyncAt !== null && videoState.time !== null) {
+                        videoState.time = videoState.time + (Date.now() - videoState.lastSyncAt);
+                        videoState.lastSyncAt = Date.now();
+                    } else if (!propValue && videoState.paused) {
+                        videoState.lastSyncAt = Date.now();
+                    }
+                    videoState.paused = propValue;
                     break;
                 }
             }
@@ -269,7 +307,7 @@ function withHTMLSubtitles(Video) {
                                     }
 
                                     cuesByTime = result;
-                                    renderSubtitles();
+                                    startRenderLoop();
                                     events.emit('extraSubtitlesTrackLoaded', selectedTrack);
                                 })
                                 .catch(function(error) {
@@ -450,6 +488,7 @@ function withHTMLSubtitles(Video) {
                     return false;
                 }
                 case 'unload': {
+                    stopRenderLoop();
                     cuesByTime = null;
                     tracks = [];
                     selectedTrackId = null;

--- a/src/withHTMLSubtitles/withHTMLSubtitles.js
+++ b/src/withHTMLSubtitles/withHTMLSubtitles.js
@@ -43,7 +43,8 @@ function withHTMLSubtitles(Video) {
         var videoState = {
             time: null,
             paused: false,
-            lastSyncAt: null
+            lastSyncAt: null,
+            playbackSpeed: 1
         };
         var rafId = null;
         var lastTimeIndex = null;
@@ -80,7 +81,7 @@ function withHTMLSubtitles(Video) {
             if (videoState.paused || videoState.lastSyncAt === null) {
                 return videoState.time;
             }
-            return videoState.time + (Date.now() - videoState.lastSyncAt);
+            return videoState.time + (Date.now() - videoState.lastSyncAt) * videoState.playbackSpeed;
         }
         function startRenderLoop() {
             if (rafId !== null) {
@@ -128,7 +129,7 @@ function withHTMLSubtitles(Video) {
 
             subtitlesElement.style.bottom = offset + '%';
             subtitlesElement.style.opacity = opacity;
-            subtitlesRenderer.render(cuesByTime, time - delay).forEach(function(cueNode) {
+            subtitlesRenderer.render(cuesByTime, timeIndex).forEach(function(cueNode) {
                 cueNode.style.display = 'inline-block';
                 cueNode.style.padding = '0.2em';
                 cueNode.style.whiteSpace = 'pre-wrap';
@@ -156,12 +157,22 @@ function withHTMLSubtitles(Video) {
                 }
                 case 'paused': {
                     if (propValue && !videoState.paused && videoState.lastSyncAt !== null && videoState.time !== null) {
-                        videoState.time = videoState.time + (Date.now() - videoState.lastSyncAt);
+                        videoState.time = videoState.time + (Date.now() - videoState.lastSyncAt) * videoState.playbackSpeed;
                         videoState.lastSyncAt = Date.now();
                     } else if (!propValue && videoState.paused) {
                         videoState.lastSyncAt = Date.now();
                     }
                     videoState.paused = propValue;
+                    break;
+                }
+                case 'playbackSpeed': {
+                    if (propValue !== null && isFinite(propValue)) {
+                        if (!videoState.paused && videoState.lastSyncAt !== null && videoState.time !== null) {
+                            videoState.time = videoState.time + (Date.now() - videoState.lastSyncAt) * videoState.playbackSpeed;
+                            videoState.lastSyncAt = Date.now();
+                        }
+                        videoState.playbackSpeed = propValue;
+                    }
                     break;
                 }
             }
@@ -284,6 +295,9 @@ function withHTMLSubtitles(Video) {
                     var selectedTrack = tracks.find(function(track) {
                         return track.id === propValue;
                     });
+                    if (!selectedTrack) {
+                        stopRenderLoop();
+                    }
                     if (selectedTrack) {
                         selectedTrackId = selectedTrack.id;
                         delay = 0;

--- a/src/withHTMLSubtitles/withHTMLSubtitles.js
+++ b/src/withHTMLSubtitles/withHTMLSubtitles.js
@@ -3,6 +3,7 @@ var cloneDeep = require('lodash.clonedeep');
 var deepFreeze = require('deep-freeze');
 var Color = require('color');
 var ERROR = require('../error');
+var binarySearchUpperBound = require('./binarySearchUpperBound');
 var subtitlesParser = require('./subtitlesParser');
 var subtitlesRenderer = require('./subtitlesRenderer');
 var subtitlesConverter = require('./subtitlesConverter');
@@ -45,6 +46,8 @@ function withHTMLSubtitles(Video) {
             lastSyncAt: null
         };
         var rafId = null;
+        var lastTimeIndex = null;
+        var forceRender = false;
         var cuesByTime = null;
         var events = new EventEmitter();
         var destroyed = false;
@@ -95,12 +98,31 @@ function withHTMLSubtitles(Video) {
             }
         }
         function renderSubtitles() {
+            var time = getCurrentTime();
+
+            if (cuesByTime === null || time === null) {
+                if (lastTimeIndex !== null) {
+                    while (subtitlesElement.hasChildNodes()) {
+                        subtitlesElement.removeChild(subtitlesElement.lastChild);
+                    }
+                    lastTimeIndex = null;
+                }
+                forceRender = false;
+                return;
+            }
+
+            var timeIndex = binarySearchUpperBound(cuesByTime.times, time - delay);
+            if (timeIndex === lastTimeIndex && !forceRender) {
+                return;
+            }
+            lastTimeIndex = timeIndex;
+            forceRender = false;
+
             while (subtitlesElement.hasChildNodes()) {
                 subtitlesElement.removeChild(subtitlesElement.lastChild);
             }
 
-            var time = getCurrentTime();
-            if (cuesByTime === null || time === null) {
+            if (timeIndex === -1) {
                 return;
             }
 
@@ -337,6 +359,7 @@ function withHTMLSubtitles(Video) {
                 case 'extraSubtitlesDelay': {
                     if (selectedTrackId !== null && propValue !== null && isFinite(propValue)) {
                         delay = parseInt(propValue, 10);
+                        forceRender = true;
                         renderSubtitles();
                         onPropChanged('extraSubtitlesDelay');
                     }
@@ -346,6 +369,7 @@ function withHTMLSubtitles(Video) {
                 case 'extraSubtitlesSize': {
                     if (propValue !== null && isFinite(propValue)) {
                         size = Math.max(0, parseInt(propValue, 10));
+                        forceRender = true;
                         renderSubtitles();
                         onPropChanged('extraSubtitlesSize');
                     }
@@ -355,6 +379,7 @@ function withHTMLSubtitles(Video) {
                 case 'extraSubtitlesOffset': {
                     if (propValue !== null && isFinite(propValue)) {
                         offset = Math.max(0, Math.min(100, parseInt(propValue, 10)));
+                        forceRender = true;
                         renderSubtitles();
                         onPropChanged('extraSubtitlesOffset');
                     }
@@ -370,6 +395,7 @@ function withHTMLSubtitles(Video) {
                             console.error('withHTMLSubtitles', error);
                         }
 
+                        forceRender = true;
                         renderSubtitles();
                         onPropChanged('extraSubtitlesTextColor');
                     }
@@ -385,6 +411,7 @@ function withHTMLSubtitles(Video) {
                             console.error('withHTMLSubtitles', error);
                         }
 
+                        forceRender = true;
                         renderSubtitles();
                         onPropChanged('extraSubtitlesBackgroundColor');
                     }
@@ -400,6 +427,7 @@ function withHTMLSubtitles(Video) {
                             console.error('withHTMLSubtitles', error);
                         }
 
+                        forceRender = true;
                         renderSubtitles();
                         onPropChanged('extraSubtitlesOutlineColor');
                     }
@@ -415,6 +443,7 @@ function withHTMLSubtitles(Video) {
                             console.error('withHTMLSubtitles', error);
                         }
 
+                        forceRender = true;
                         renderSubtitles();
                         onPropChanged('extraSubtitlesOpacity');
                     }
@@ -489,6 +518,7 @@ function withHTMLSubtitles(Video) {
                 }
                 case 'unload': {
                     stopRenderLoop();
+                    lastTimeIndex = null;
                     cuesByTime = null;
                     tracks = [];
                     selectedTrackId = null;


### PR DESCRIPTION
Subtitle rendering was tied to `time` prop updates which can be infrequent (update every second), causing subtitles to appear with a delay.

Instead of rendering on prop updates, subtitles now render through a requestAnimationFrame loop that syncs on `time` prop update.

Skipping DOM updates when the active cue hasn't changed between frames is also applied as an optimisation.