### PR TITLE
Fix: Force streaming server proxy when embedded subtitles

### DIFF
--- a/src/withStreamingServer/withStreamingServer.js
+++ b/src/withStreamingServer/withStreamingServer.js
@@ -10,12 +10,6 @@ var isPlayerLoaded = require('./isPlayerLoaded');
 var supportsTranscoding = require('../supportsTranscoding');
 var ERROR = require('../error');
 
-function hasEmbeddedSubtitles(probe) {
-    return Array.isArray(probe && probe.streams) && probe.streams.some(function(stream) {
-        return stream && stream.track === 'subtitle';
-    });
-}
-
 function withStreamingServer(Video) {
     function VideoWithStreamingServer(options) {
         options = options || {};
@@ -368,10 +362,6 @@ function withStreamingServer(Video) {
                         return resp.json();
                     })
                     .then(function(probe) {
-                        if (hasEmbeddedSubtitles(probe)) {
-                            return false;
-                        }
-
                         var isFormatSupported = options.formats.some(function(format) {
                             return probe.format.name.indexOf(format) !== -1;
                         });
@@ -385,7 +375,10 @@ function withStreamingServer(Video) {
 
                             return true;
                         });
-                        return isFormatSupported && areStreamsSupported;
+                        var hasEmbeddedSubtitles = probe.streams.some(function(stream) {
+                            return stream.track === 'subtitle';
+                        });
+                        return isFormatSupported && areStreamsSupported && !hasEmbeddedSubtitles;
                     })
                     .catch(function() {
                         // this uses content-type header in HTMLVideo which

--- a/src/withStreamingServer/withStreamingServer.js
+++ b/src/withStreamingServer/withStreamingServer.js
@@ -10,6 +10,12 @@ var isPlayerLoaded = require('./isPlayerLoaded');
 var supportsTranscoding = require('../supportsTranscoding');
 var ERROR = require('../error');
 
+function hasEmbeddedSubtitles(probe) {
+    return Array.isArray(probe && probe.streams) && probe.streams.some(function(stream) {
+        return stream && stream.track === 'subtitle';
+    });
+}
+
 function withStreamingServer(Video) {
     function VideoWithStreamingServer(options) {
         options = options || {};
@@ -362,6 +368,10 @@ function withStreamingServer(Video) {
                         return resp.json();
                     })
                     .then(function(probe) {
+                        if (hasEmbeddedSubtitles(probe)) {
+                            return false;
+                        }
+
                         var isFormatSupported = options.formats.some(function(format) {
                             return probe.format.name.indexOf(format) !== -1;
                         });


### PR DESCRIPTION
## Summary

This fixes a playback decision issue in Chrome when `stremio-server` is available.

Previously, if the probe reported a browser-supported video/audio codec combination, `stremio-video` could choose the original media URL and skip the streaming server. That breaks embedded subtitles for formats like MKV/MP4, because Chrome cannot extract/decode those subtitle tracks natively.

Closes [#1110](https://github.com/Stremio/stremio-web/issues/1110)

## What changed

- added a probe check in `withStreamingServer.canPlayStream()`
- if the probe reports embedded subtitles, native playback is no longer considered playable
- this forces playback through `streamingServerURL`, allowing the server to handle subtitle extraction/conversion

## Why

Even when Chrome can play the video codec itself, embedded subtitle tracks still require the streaming server path to work correctly.

## Example

Probe result contains subtitle streams such as:

- `track: "subtitle"`

In this case, playback should use the streaming server proxy/HLS path instead of the original file URL.

## Result

Streams with embedded subtitles now consistently go through the streaming server, which restores subtitle support in Chrome.
