### PR TITLE
fix(HTMLVideo): recover from hls.js errors to prevent silent audio

### DIFF
--- a/src/HTMLVideo/HTMLVideo.js
+++ b/src/HTMLVideo/HTMLVideo.js
@@ -579,6 +579,52 @@ function HTMLVideo(options) {
 
                             if (contentType === 'application/vnd.apple.mpegurl' && Hls.isSupported()) {
                                 hls = new Hls(HLS_CONFIG);
+                                var MEDIA_ERROR_RECOVERY_LIMIT = 3;
+                                var MEDIA_ERROR_BURST_WINDOW_MS = 3000;
+                                var lastMediaErrorAt = 0;
+                                var mediaErrorRecoveryAttempts = 0;
+                                function isStallingNonFatalError(details) {
+                                    return details === Hls.ErrorDetails.BUFFER_STALLED_ERROR
+                                        || details === Hls.ErrorDetails.BUFFER_APPENDING_ERROR
+                                        || details === Hls.ErrorDetails.AUDIO_TRACK_LOAD_ERROR
+                                        || details === Hls.ErrorDetails.AUDIO_TRACK_LOAD_TIMEOUT;
+                                }
+                                function recoverFromHlsError(_, data) {
+                                    if (!data.fatal) {
+                                        if (isStallingNonFatalError(data.details)) {
+                                            hls.startLoad();
+                                        }
+                                        return;
+                                    }
+                                    if (data.type === Hls.ErrorTypes.NETWORK_ERROR) {
+                                        hls.startLoad();
+                                        return;
+                                    }
+                                    if (data.type !== Hls.ErrorTypes.MEDIA_ERROR) {
+                                        return;
+                                    }
+                                    if (mediaErrorRecoveryAttempts >= MEDIA_ERROR_RECOVERY_LIMIT) {
+                                        // hls.js fatal MEDIA_ERROR does not bubble through videoElement.error, so surface it explicitly once recovery is exhausted.
+                                        onError(Object.assign({}, ERROR.HTML_VIDEO.MEDIA_ERR_DECODE, {
+                                            critical: true,
+                                            error: data
+                                        }));
+                                        return;
+                                    }
+                                    var now = Date.now();
+                                    var withinRecoveryWindow = now - lastMediaErrorAt < MEDIA_ERROR_BURST_WINDOW_MS;
+                                    lastMediaErrorAt = now;
+                                    mediaErrorRecoveryAttempts++;
+                                    if (withinRecoveryWindow) {
+                                        // Second consecutive media error in hls.js usually means the audio codec is the culprit; swap before retrying.
+                                        hls.swapAudioCodec();
+                                    }
+                                    hls.recoverMediaError();
+                                }
+                                hls.on(Hls.Events.ERROR, recoverFromHlsError);
+                                hls.on(Hls.Events.FRAG_BUFFERED, function() {
+                                    mediaErrorRecoveryAttempts = 0;
+                                });
                                 hls.on(Hls.Events.AUDIO_TRACKS_UPDATED, function() {
                                     onPropChanged('audioTracks');
                                     onPropChanged('selectedAudioTrackId');


### PR DESCRIPTION
## Summary
Adds an `Hls.Events.ERROR` listener in `HTMLVideo` so a small set of stalling conditions that hls.js does not recover from on its own no longer leave audio silent while video keeps playing.

## Why
`HTMLVideo.js` constructs an `Hls` instance with no error listener and never calls `recoverMediaError`, `swapAudioCodec`, or `startLoad`. When hls.js exhausts retries on `bufferStalledError`, `bufferAppendingError`, `audioTrackLoadError`, `audioTrackLoadTimeOut`, or hits a fatal `NETWORK_ERROR`/`MEDIA_ERROR`, the audio source buffer can stall while the video element keeps decoding video. The host UI shows normal, non-muted state because nothing toggles `videoElement.muted` or `videoElement.volume`. Users see silent playback until they reload. Only HTMLVideo is affected; ShellVideo and external players bypass hls.js.

## Behavior
- Non-fatal error: `startLoad()` only for the four known stalling details. All other non-fatal errors are left to hls.js's own state machine.
- Fatal `NETWORK_ERROR`: `startLoad()`.
- Fatal `MEDIA_ERROR`: first occurrence calls `recoverMediaError()`; a second within 3s adds `swapAudioCodec()` before recovery. Capped at 3 attempts; counter resets on `FRAG_BUFFERED`.
- Other fatal types: untouched. The existing `videoElement.onerror` path continues to map decode errors as before.

## Test plan
- [x] Play an HLS stream that triggers `BUFFER_STALLED_ERROR` and verify audio resumes without reload.
- [x] Play an HLS stream that triggers a fatal `MEDIA_ERROR` and verify audio recovers; force a second within 3s and verify codec swap kicks in.
- [x] Force repeated unrecoverable `MEDIA_ERROR`s and verify that after 3 attempts the player emits a critical `MEDIA_ERR_DECODE` and unloads.
- [x] Switch streams and verify per-load state resets cleanly (no cross-load codec-swap or attempt-counter behavior).
- [x] `npm run lint` passes.
