### PR TITLE
fix(streaming-server): resolve subtitle filename for auto-picked torrents

### DIFF
--- a/src/withStreamingServer/convertStream.js
+++ b/src/withStreamingServer/convertStream.js
@@ -46,13 +46,33 @@ function convertStream(streamingServerURL, stream, seriesInfo, streamingServerSe
             } else {
                 var proxyStreamsEnabled = streamingServerSettings && streamingServerSettings.proxyStreamsEnabled;
                 var proxyHeaders = stream.behaviorHints && stream.behaviorHints.proxyHeaders;
+                var resolved;
                 if (proxyStreamsEnabled || proxyHeaders) {
                     var requestHeaders = proxyHeaders && proxyHeaders.request ? proxyHeaders.request : {};
                     var responseHeaders = proxyHeaders && proxyHeaders.response ? proxyHeaders.response : {};
-                    resolve({ url: buildProxyUrl(streamingServerURL, stream.url, requestHeaders, responseHeaders) });
+                    resolved = { url: buildProxyUrl(streamingServerURL, stream.url, requestHeaders, responseHeaders) };
                 } else {
-                    resolve({ url: stream.url });
+                    resolved = { url: stream.url };
                 }
+                // Propagate infoHash/fileIdx so fetchFilename can hit stats.json
+                // instead of leaking the URL fragment as the filename.
+                if (typeof stream.infoHash === 'string' && stream.infoHash.length > 0) {
+                    resolved.infoHash = stream.infoHash.toLowerCase();
+                    if (stream.fileIdx !== null && stream.fileIdx !== undefined && isFinite(stream.fileIdx)) {
+                        resolved.fileIdx = stream.fileIdx;
+                    }
+                } else {
+                    // Fallback for addons shipping pre-computed streaming-server URLs.
+                    try {
+                        var parsed = new URL(stream.url);
+                        var parts = parsed.pathname.split('/').filter(Boolean);
+                        if (parts.length === 2 && /^[a-f0-9]{40}$/i.test(parts[0]) && /^-?\d+$/.test(parts[1])) {
+                            resolved.infoHash = parts[0].toLowerCase();
+                            resolved.fileIdx = parseInt(parts[1], 10);
+                        }
+                    } catch (_e) { /* unparsable URL */ }
+                }
+                resolve(resolved);
             }
 
             return;

--- a/src/withStreamingServer/fetchVideoParams.js
+++ b/src/withStreamingServer/fetchVideoParams.js
@@ -46,7 +46,30 @@ function fetchFilename(streamingServerURL, mediaURL, infoHash, fileIdx, behavior
     }
 
     if (infoHash) {
-        return fetch(url.resolve(streamingServerURL, '/' + encodeURIComponent(infoHash) + '/' + encodeURIComponent(fileIdx) + '/stats.json'))
+        // fileIdx -1 means auto-pick; /-1/stats.json has no streamName,
+        // so resolve via engine guessedFileIdx instead.
+        var fileIdxNum = typeof fileIdx === 'string' ? parseInt(fileIdx, 10) : fileIdx;
+        var hasSpecificFileIdx = fileIdxNum !== null && fileIdxNum !== -1 && isFinite(fileIdxNum);
+
+        if (hasSpecificFileIdx) {
+            return fetch(url.resolve(streamingServerURL, '/' + encodeURIComponent(infoHash) + '/' + encodeURIComponent(fileIdx) + '/stats.json'))
+                .then(function(resp) {
+                    if (resp.ok) {
+                        return resp.json();
+                    }
+
+                    throw new Error(resp.status + ' (' + resp.statusText + ')');
+                })
+                .then(function(resp) {
+                    if (!resp || typeof resp.streamName !== 'string') {
+                        throw new Error('Could not retrieve filename from torrent');
+                    }
+
+                    return resp.streamName;
+                });
+        }
+
+        return fetch(url.resolve(streamingServerURL, '/' + encodeURIComponent(infoHash) + '/stats.json'))
             .then(function(resp) {
                 if (resp.ok) {
                     return resp.json();
@@ -54,12 +77,31 @@ function fetchFilename(streamingServerURL, mediaURL, infoHash, fileIdx, behavior
 
                 throw new Error(resp.status + ' (' + resp.statusText + ')');
             })
-            .then(function(resp) {
-                if (!resp || typeof resp.streamName !== 'string') {
-                    throw new Error('Could not retrieve filename from torrent');
+            .then(function(stats) {
+                if (!stats || !Array.isArray(stats.files)) {
+                    throw new Error('Could not retrieve file list from torrent');
                 }
 
-                return resp.streamName;
+                // Prefer guessedFileIdx — the file the engine is streaming.
+                var guessed = typeof stats.guessedFileIdx === 'number' ? stats.files[stats.guessedFileIdx] : null;
+                if (guessed && typeof guessed.name === 'string') {
+                    return guessed.name;
+                }
+
+                // Fallback: largest video file (mirrors server's GuessFileIdx for movies).
+                var videoExt = /\.(mp4|mkv|avi|mov|wmv|flv|webm|m4v|mpg|mpeg|ts|m2ts)$/i;
+                var pool = stats.files.filter(function(f) { return f && typeof f.name === 'string' && videoExt.test(f.name); });
+                if (pool.length === 0) {
+                    pool = stats.files.filter(function(f) { return f && typeof f.name === 'string'; });
+                }
+                var largest = pool.reduce(function(best, f) {
+                    return (!best || (f.length || 0) > (best.length || 0)) ? f : best;
+                }, null);
+                if (largest && typeof largest.name === 'string') {
+                    return largest.name;
+                }
+
+                throw new Error('Could not retrieve filename from torrent');
             });
     }
 


### PR DESCRIPTION

### Summary

Subtitle addons receive `filename=-1?` for any torrent stream whose addon entry has `fileIdx: null` (single-file torrents, or any torrent where the addon doesn't pin a specific file index). Most addons return no results for that bogus filename, so users see no extension subtitles for those torrents — even though the same movie via a different torrent works fine.

This PR fixes the JS-side data path so the real filename is sent to subtitle addons.

### Reproduction

1. Start any movie from an addon stream that has `fileIdx: null`. Single-file torrent results from common addons (Torrentio, etc.) typically reproduce this — for example a TPB+ entry for Interstellar.
2. Open DevTools → Network → filter `subtitle`.
3. Observe the addon request to (e.g.) `opensubtitles.stremio.homes`:

   **Before:**
   ```
   …/subtitles/movie/tt0816692/filename=-1%3F&videoSize=4824382127&videoHash=b7fdee88fd97397d.json
   ```
   404 / no subtitles returned.

   **After (this PR):**
   ```
   …/subtitles/movie/tt0816692/filename=Interstellar.2014.1080p.BluRay.DDP5.1.x265.10bit-GalaxyRG265.mkv&videoSize=4824382127&videoHash=b7fdee88fd97397d.json
   ```
   200 with subtitle list.

A torrent with an explicit `fileIdx` (e.g. multi-file release with `fileIdx: 2`) was unaffected — that confirmed the trigger condition was `fileIdx: null` specifically.

### Root cause

Three layers cooperate to produce the bug; the fix is at the JS layer in this repo.

**1. `stremio-core` (Rust) maps `file_idx: None` → `-1` as a URL sentinel.**

In `src/types/resource/stream.rs::convert` the streaming URL is built as:

```rust
&file_idx.map_or_else(|| "-1".to_string(), |idx| idx.to_string())
```

So `<server>/<infoHash>/-1?` is the streaming URL when no specific file index is known. `-1` means "let the streaming server pick a file."

**2. `convertStream.js` drops `infoHash` and `fileIdx` for streams that have a `url`.**

The Rust-converted stream payload carries `url`, `infoHash`, and `fileIdx` as sibling fields. The current JS code branches purely on `typeof stream.url === 'string'` and resolves with just `{ url }`, ignoring the sibling identity fields. Downstream code therefore loses access to them.

**3. `fetchFilename` falls back to `pop()`-ing the URL.**

In `fetchVideoParams.js`:

```js
if (infoHash) {
    return fetch(`/<hash>/<idx>/stats.json`)…
}
return Promise.resolve(decodeURIComponent(mediaURL.split('/').pop()));
```

With `infoHash` undefined (because of #2), the fallback fires. For `<server>/<hash>/-1?` the popped segment is the literal string `-1?`. That string flows up as `videoParams.filename`, gets dispatched to core via `Player.VideoParamsChanged`, and ends up in the addon URL.

**Latent issue uncovered while fixing #2:** even after restoring `infoHash`, calling `/<hash>/-1/stats.json` returns no `streamName`, because the bundled streaming server's `getStatistics(engine, idx)` only attaches `streamName` when `e.torrent.files[idx]` exists, and `files["-1"]` is `undefined`. So `fetchFilename` would then reject and `videoParams.filename` would silently end up `null` instead of being filename-matched. We address this too.

### Changes

#### `src/withStreamingServer/convertStream.js`

In the `stream.url` branch (non-magnet), propagate sibling `infoHash`/`fileIdx` fields when they are present on the stream object. As a safety net for older/legacy addons that pre-compute the local URL themselves without setting sibling fields, also try to recover them by parsing the URL when it matches `<server>/<infoHash40hex>/<fileIdx>`.

```js
if (typeof stream.infoHash === 'string' && stream.infoHash.length > 0) {
    resolved.infoHash = stream.infoHash.toLowerCase();
    if (stream.fileIdx !== null && stream.fileIdx !== undefined && isFinite(stream.fileIdx)) {
        resolved.fileIdx = stream.fileIdx;
    }
} else {
    try {
        var parsed = new URL(stream.url);
        var parts = parsed.pathname.split('/').filter(Boolean);
        if (parts.length === 2 && /^[a-f0-9]{40}$/i.test(parts[0]) && /^-?\d+$/.test(parts[1])) {
            resolved.infoHash = parts[0].toLowerCase();
            resolved.fileIdx = parseInt(parts[1], 10);
        }
    } catch (e) { /* not a parsable URL — leave resolved as-is */ }
}
```

#### `src/withStreamingServer/fetchVideoParams.js`

When `fileIdx` is `-1` (auto-pick) or null, query `/<hash>/stats.json` (no idx) instead of `/<hash>/-1/stats.json`. Resolve the actual file via the engine's `guessedFileIdx` set during `/<hash>/create`. Fall back to "largest video file in the torrent" if `guessedFileIdx` isn't present, mirroring the server's own `GuessFileIdx` heuristic for movies.

```js
var fileIdxNum = typeof fileIdx === 'string' ? parseInt(fileIdx, 10) : fileIdx;
var hasSpecificFileIdx = fileIdxNum !== null && fileIdxNum !== -1 && isFinite(fileIdxNum);

if (hasSpecificFileIdx) {
    // existing /<hash>/<idx>/stats.json path, unchanged
}

return fetch(`<server>/<hash>/stats.json`)
    .then(stats => {
        const guessed = typeof stats.guessedFileIdx === 'number' ? stats.files[stats.guessedFileIdx] : null;
        if (guessed?.name) return guessed.name;

        // largest video file fallback
        const videoExt = /\.(mp4|mkv|avi|mov|wmv|flv|webm|m4v|mpg|mpeg|ts|m2ts)$/i;
        let pool = stats.files.filter(f => f?.name && videoExt.test(f.name));
        if (pool.length === 0) pool = stats.files.filter(f => f?.name);
        const largest = pool.reduce((best, f) => (!best || (f.length || 0) > (best.length || 0)) ? f : best, null);
        if (largest?.name) return largest.name;

        throw new Error('Could not retrieve filename from torrent');
    });
```

(Actual diff uses ES5 syntax to match the surrounding file style.)

### Test plan

- [x] Manual repro on macOS desktop Stremio v5.1.22 (WKWebView, talking to local streaming server). Failing torrent: TPB+ Interstellar 1080p (single file, `fileIdx: null`). Working torrent (regression baseline): UHD remux release with `fileIdx: 2`.
- [x] Verified addon URL changes from `filename=-1%3F` to the real filename, and OpenSubtitles addons return populated subtitle lists.
- [x] Verified the working torrent still works (no regression).
- [x] Confirmed the `infoHash` propagation also handles the legacy URL-only stream case (pre-converted streaming-server URLs from older addons that don't set the sibling field).

What I haven't tested:
- TV apps (Tizen / WebOS / Vidaa / Titan). The change is in shared code (`withStreamingServer`) so behavior should match the desktop case, but I don't have hardware to verify.
- Series content (with `seriesInfo` for episode matching). `fileIdx` is usually a real number for series — the bug presents on movies most often — but the fallback path is exercised here so worth a sanity check.

### Related

- Failing torrent stream object captured in user testing:
  ```json
  {
    "infoHash": "9bb5a1b259c6a945eaf71ce162926514712296c7",
    "fileIdx": null,
    "announce": [],
    "name": "TPB+",
    "description": "Interstellar.2014.1080p.BluRay.DDP5.1.x265.10bit-GalaxyRG265\n📺 1080p BluRay\n👤 118 💾 4.49 GB"
  }
  ```
- Bundled streaming server's `getStatistics(engine, idx)` shows the `streamName` gap for `idx="-1"` (server.js around line 18331).
- `stremio-core` URL builder: `src/types/resource/stream.rs::convert`, the `StreamSource::Torrent` arm (line ~588 in current main).

---

_Researched by Claude Opus 4.7; reviewed and tested by me._

---

