### PR TITLE
feat: add secondary subtitle track support via mpv secondary-sid

### DIFF
--- a/src/ShellVideo/ShellVideo.js
+++ b/src/ShellVideo/ShellVideo.js
@@ -20,6 +20,7 @@ var stremioToMPVProps = {
     'selectedAudioTrackId': 'aid',
     'subtitlesTracks': 'subtitlesTracks',
     'selectedSubtitlesTrackId': 'sid',
+    'selectedSecondarySubtitlesTrackId': 'secondary-sid',
     'subtitlesSize': 'sub-scale',
     'subtitlesOffset': 'sub-pos',
     'subtitlesDelay': 'sub-delay',
@@ -81,6 +82,7 @@ function ShellVideo(options) {
     ipc.send('mpv-observe-prop', 'aid');
     ipc.send('mpv-observe-prop', 'vid');
     ipc.send('mpv-observe-prop', 'sid');
+    ipc.send('mpv-observe-prop', 'secondary-sid');
     ipc.send('mpv-observe-prop', 'sub-scale');
     ipc.send('mpv-observe-prop', 'sub-pos');
     ipc.send('mpv-observe-prop', 'sub-delay');
@@ -189,6 +191,7 @@ function ShellVideo(options) {
             }
             case 'aid':
             case 'sid':
+            case 'secondary-sid':
             case 'vid': {
                 props[args.name] = embeddedProp(args);
                 break;
@@ -370,6 +373,21 @@ function ShellVideo(options) {
                 onPropChanged('selectedSubtitlesTrackId');
                 break;
             }
+            case 'selectedSecondarySubtitlesTrackId': {
+                if (stream !== null) {
+                    if (propValue) {
+                        var actualSecId = propValue.slice('EMBEDDED_'.length);
+                        ipc.send('mpv-set-prop', ['secondary-sid', actualSecId]);
+                        events.emit('secondarySubtitlesTrackLoaded', propValue);
+                    } else {
+                        // turn off secondary subs
+                        ipc.send('mpv-set-prop', ['secondary-sid', 'no']);
+                        props['secondary-sid'] = null;
+                    }
+                }
+                onPropChanged('selectedSecondarySubtitlesTrackId');
+                break;
+            }
             case 'subtitlesSize': {
                 ipc.send('mpv-set-prop', [stremioToMPVProps[propName], propValue * SUBS_SCALE_FACTOR]);
                 break;
@@ -472,6 +490,7 @@ function ShellVideo(options) {
                     buffered: null,
                     aid: null,
                     sid: null,
+                    'secondary-sid': null,
                 };
                 avgDuration = 0;
                 ipc.send('mpv-command', ['stop']);
@@ -546,6 +565,7 @@ ShellVideo.manifest = {
         'ended',
         'error',
         'subtitlesTrackLoaded',
+        'secondarySubtitlesTrackLoaded',
     ],
 };
 


### PR DESCRIPTION
## Summary

Adds `selectedSecondarySubtitlesTrackId` prop to ShellVideo, mapping it to mpv's native `secondary-sid` property. This enables rendering a second subtitle track simultaneously with the primary one for language learning workflows.

### Changes (`src/ShellVideo/ShellVideo.js`)
- Added `selectedSecondarySubtitlesTrackId: 'secondary-sid'` to `stremioToMPVProps` mapping
- Added `mpv-observe-prop` for `secondary-sid`
- Added `secondary-sid` case in the mpv property change event handler
- Added `selectedSecondarySubtitlesTrackId` case in `setProp()`
- Reset `secondary-sid` to null on `unload`
- Added `secondarySubtitlesTrackLoaded` event to manifest

### Related
- stremio-web: adds dual subtitle UI
- stremio-translations: adds PLAYER_SUBTITLES_SECONDARY key

### Related PRs
- stremio-web: https://github.com/Stremio/stremio-web/pull/1286
- stremio-translations: https://github.com/Stremio/stremio-translations/pull/1053