### PR TITLE
fix(TizenVideo): render embedded ASS/SSA cues and label tracks on Tizen < 6

### DIFF
--- a/src/TizenVideo/TizenVideo.js
+++ b/src/TizenVideo/TizenVideo.js
@@ -5,7 +5,25 @@ var Color = require('color');
 var ERROR = require('../error');
 var getTracksData = require('../tracksData');
 
-var SSA_DESCRIPTORS_REGEX = /^\{(\\an[1-8])+\}/i;
+// ASS/SSA override blocks: alignment {\an8}, styling {\i1}, positioning
+// {\pos(..)}, colors {\c&H..}, fades {\fad(..)} etc. The native Tizen player
+// forwards these inline with the cue text, so they must be stripped before
+// rendering instead of only removing a leading {\anN} tag.
+var SSA_BLOCK_REGEX = /\{[^}]*\}/g;
+// ASS line breaks (\N hard, \n soft) and hard space (\h).
+var SSA_NEWLINE_REGEX = /\\N|\\n/g;
+var SSA_HARD_SPACE_REGEX = /\\h/g;
+
+function cleanEmbeddedSubtitle(text) {
+    if (typeof text !== 'string') {
+        return '';
+    }
+
+    return text
+        .replace(SSA_BLOCK_REGEX, '')
+        .replace(SSA_HARD_SPACE_REGEX, ' ')
+        .replace(SSA_NEWLINE_REGEX, '\n');
+}
 
 function TizenVideo(options) {
     options = options || {};
@@ -51,7 +69,7 @@ function TizenVideo(options) {
     function renderSubtitle(duration, text) {
         if (disabledSubs) return;
         var now = getProp('time');
-        var cleanedText = text.replace(SSA_DESCRIPTORS_REGEX, '');
+        var cleanedText = cleanEmbeddedSubtitle(text);
 
         // we ignore custom delay here, it's not needed for embedded subs
         lastSub = {
@@ -72,7 +90,16 @@ function TizenVideo(options) {
         subtitlesElement.style.opacity = subtitlesOpacity;
 
         var cueNode = document.createElement('span');
-        cueNode.innerHTML = cleanedText;
+        // Build the cue from text nodes split on line breaks. This renders
+        // multi-line ASS/SRT cues correctly and avoids injecting the raw
+        // subtitle string as HTML.
+        var cueLines = cleanedText.split('\n');
+        for (var lineIndex = 0; lineIndex < cueLines.length; lineIndex++) {
+            if (lineIndex > 0) {
+                cueNode.appendChild(document.createElement('br'));
+            }
+            cueNode.appendChild(document.createTextNode(cueLines[lineIndex]));
+        }
         cueNode.style.display = 'inline-block';
         cueNode.style.padding = '0.2em';
         cueNode.style.fontSize = Math.floor(size / 25) + 'vmin';
@@ -625,17 +652,14 @@ function TizenVideo(options) {
                     }
                     onPropChanged('buffering');
 
-                    var tizenVersion = false;
-
-                    var TIZEN_MATCHES = navigator.userAgent.match(/Tizen (\d+\.\d+)/i);
-
-                    if (TIZEN_MATCHES && TIZEN_MATCHES[1]) {
-                        tizenVersion = parseFloat(TIZEN_MATCHES[1]);
-                    }
-
-                    if (!tizenVersion || tizenVersion >= 6) {
-                        retrieveExtendedTracks();
-                    }
+                    // Extended track metadata (language / label) comes from the
+                    // local streaming server and is independent of the Tizen
+                    // player version. Always fetch it: the previous version gate
+                    // skipped Tizen < 6 entirely, and since the lazy fallback was
+                    // removed those devices surfaced every embedded track as
+                    // "UNKNOWN". retrieveExtendedTracks() is self-guarded against
+                    // repeat calls and a missing stream.
+                    retrieveExtendedTracks();
 
                     AVPlay.open(stream.url);
                     AVPlay.setDisplayRect(0, 0, window.innerWidth, window.innerHeight);


### PR DESCRIPTION
## Summary

Fixes three distinct, client-side defects in `TizenVideo` that together
account for the long-standing reports of embedded subtitles "not loading"
on Samsung TVs (Stremio/stremio-bugs#641 — also seen on LG/WebOS, which
shares this rendering approach).

The Jan-2025 work moved embedded-subtitle rendering off the native AVPlay
cue renderer and onto a custom HTML overlay driven by the
`onsubtitlechange(duration, text)` callback. That fixed styling control,
but left three gaps that this PR closes.

## What was broken

### 1. Inline ASS/SSA override tags rendered as literal text
The only cleanup applied to a cue was:

```js
var SSA_DESCRIPTORS_REGEX = /^\{(\\an[1-8])+\}/i;
cleanedText = text.replace(SSA_DESCRIPTORS_REGEX, '');
```

That strips **only a leading `{\anN}` alignment tag**. ASS dialogue that the
native player forwards still contains inline override blocks — `{\i1}`,
`{\b1}`, `{\pos(...)}`, `{\fad(...)}`, colour tags — which were rendered
verbatim, e.g. `{\i1}italic{\i0}` showed up on screen as `{\i1}italic{\i0}`.
This is a large part of why anime (ASS-heavy) looked broken.

### 2. Line breaks not handled + raw `innerHTML`
`\N` / `\n` (ASS line breaks) and `\h` (hard space) were not converted, so
multi-line cues collapsed onto one line with literal escape sequences. The
cue text was also assigned via `cueNode.innerHTML = cleanedText`, injecting
the raw subtitle string as HTML.

### 3. Embedded tracks shown as "UNKNOWN" on Tizen < 6
Track language/label come from the local streaming server
(`getTracksData` → `retrieveExtendedTracks`) and are independent of the
player version. But the fetch was gated:

```js
if (!tizenVersion || tizenVersion >= 6) {
    retrieveExtendedTracks();
}
```

`retrieveExtendedTracks()` is now the **only** call site — the lazy
fallback that used to re-trigger it when a track's language was `null`
was removed in *"Simplify Extended Track Data Logic"* (4bd7c80). As a
result, on **Tizen < 6** extended metadata is never fetched and every
embedded track surfaces as "UNKNOWN" (matches the Tizen 5.5 and "UNKNOWN"
reports in #641).

## Changes

- Replace `SSA_DESCRIPTORS_REGEX` with `cleanEmbeddedSubtitle()`, which
  strips **all** `{...}` ASS/SSA override blocks and converts `\N`/`\n`
  to newlines and `\h` to a space.
- Build the cue from text nodes split on line breaks instead of
  `innerHTML` — renders multi-line cues correctly and removes the HTML
  injection vector. The cleaner is idempotent, so the `refreshSubtitle()`
  re-render path (which reuses the stored cleaned text) stays correct.
- Always call `retrieveExtendedTracks()` (it is self-guarded by
  `gotTraktData` and a `stream !== null` check), restoring track labels
  on older Tizen devices.

No behaviour change for tracks the native player already decoded cleanly.

## Scope / what this does *not* fix

This does not make AVPlay decode subtitle codecs it refuses to decode
(bitmap PGS/VOBSUB, and ASS/SSA on firmware that drops them entirely → no
`onsubtitlechange` events at all). That needs server-side extraction of the
embedded track to WebVTT plus timing the overlay off `oncurrentplaytime`,
which is a larger cross-repo change (streaming-server + TizenVideo). Happy
to follow up with that if there's interest. This PR fixes the cases where
the player *does* emit cues but they render wrong, plus the mislabeling.

## Testing

- `npm run lint` passes (exit 0).
- The repo has no unit-test harness; `cleanEmbeddedSubtitle()` was verified
  in isolation against ASS override tags, `\N`/`\n`/`\h`, plain SRT lines,
  non-string input, and idempotency (cleaning already-cleaned text).
- Manual on-device verification on a Tizen TV is still recommended before
  merge, since the native callback payload format can only be confirmed there.
