### PR TITLE
Emit ended only on eof end-file reason

### DIFF
--- a/src/ShellVideo/ShellVideo.js
+++ b/src/ShellVideo/ShellVideo.js
@@ -257,8 +257,9 @@ function ShellVideo(options) {
         }
     });
     ipc.on('mpv-event-ended', function(args) {
+        // older shells report 'other' for every non-error reason, including eof
         if (args.error) onError(args.error);
-        else onEnded();
+        else if (!args.reason || args.reason === 'eof' || args.reason === 'other') onEnded();
     });
 
     function getProp(propName) {


### PR DESCRIPTION
ShellVideo emitted ended for every mpv end-file event, including the stop caused by loading the next video, which made the player skip episodes when binge watching. Only emit ended for eof. Older shells report "other" for all non-error reasons so they keep the current behavior.