### PR TITLE
Add HTML5 Picture in Picture controls

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
         "url": "https://github.com/Stremio/stremio-video"
     },
     "scripts": {
+        "test": "node --test tests/*.test.js",
         "lint": "eslint src"
     },
     "dependencies": {

--- a/src/HTMLVideo/HTMLVideo.js
+++ b/src/HTMLVideo/HTMLVideo.js
@@ -6,6 +6,7 @@ var Color = require('color');
 var ERROR = require('../error');
 var getContentType = require('./getContentType');
 var HLS_CONFIG = require('./hlsConfig');
+var pictureInPicture = require('./pictureInPicture');
 
 function HTMLVideo(options) {
     options = options || {};
@@ -82,6 +83,12 @@ function HTMLVideo(options) {
         onPropChanged('buffering');
         onPropChanged('buffered');
     };
+    videoElement.onenterpictureinpicture = function() {
+        onPropChanged('pictureInPictureActive');
+    };
+    videoElement.onleavepictureinpicture = function() {
+        onPropChanged('pictureInPictureActive');
+    };
     videoElement.onvolumechange = function() {
         onPropChanged('volume');
         onPropChanged('muted');
@@ -133,7 +140,9 @@ function HTMLVideo(options) {
         muted: false,
         playbackSpeed: false,
         videoScale: false,
-        fullscreen: false
+        fullscreen: false,
+        pictureInPicturePossible: false,
+        pictureInPictureActive: false
     };
 
     function getProp(propName) {
@@ -336,6 +345,12 @@ function HTMLVideo(options) {
                     return null;
                 }
                 return videoElement.webkitDisplayingFullscreen === true || document.fullscreenElement === videoElement;
+            }
+            case 'pictureInPicturePossible': {
+                return stream !== null && pictureInPicture.isPictureInPicturePossible(videoElement, document);
+            }
+            case 'pictureInPictureActive': {
+                return pictureInPicture.isPictureInPictureActive(videoElement, document);
             }
             default: {
                 return null;
@@ -581,7 +596,21 @@ function HTMLVideo(options) {
                 }
                 break;
             }
+            case 'pictureInPictureActive': {
+                if (propValue) {
+                    command('enterPictureInPicture');
+                } else {
+                    command('exitPictureInPicture');
+                }
+                break;
+            }
         }
+    }
+    function pictureInPictureError(error) {
+        events.emit('error', Object.assign({}, ERROR.HTML_VIDEO.PICTURE_IN_PICTURE_FAILED, {
+            critical: false,
+            error: error
+        }));
     }
     function command(commandName, commandArgs) {
         switch (commandName) {
@@ -603,6 +632,8 @@ function HTMLVideo(options) {
                     onPropChanged('audioTracks');
                     onPropChanged('selectedAudioTrackId');
                     onPropChanged('fullscreen');
+                    onPropChanged('pictureInPicturePossible');
+                    onPropChanged('pictureInPictureActive');
                     getContentType(stream)
                         .then(function(contentType) {
                             if (stream !== commandArgs.stream) {
@@ -669,6 +700,31 @@ function HTMLVideo(options) {
                 onPropChanged('audioTracks');
                 onPropChanged('selectedAudioTrackId');
                 onPropChanged('fullscreen');
+                onPropChanged('pictureInPicturePossible');
+                onPropChanged('pictureInPictureActive');
+                break;
+            }
+            case 'enterPictureInPicture': {
+                if (stream === null || !pictureInPicture.isPictureInPicturePossible(videoElement, document)) {
+                    return;
+                }
+
+                videoElement.requestPictureInPicture().catch(pictureInPictureError);
+                break;
+            }
+            case 'exitPictureInPicture': {
+                if (pictureInPicture.isPictureInPictureActive(videoElement, document) &&
+                    typeof document.exitPictureInPicture === 'function') {
+                    document.exitPictureInPicture().catch(pictureInPictureError);
+                }
+                break;
+            }
+            case 'togglePictureInPicture': {
+                if (pictureInPicture.isPictureInPictureActive(videoElement, document)) {
+                    command('exitPictureInPicture');
+                } else {
+                    command('enterPictureInPicture');
+                }
                 break;
             }
             case 'destroy': {
@@ -698,6 +754,8 @@ function HTMLVideo(options) {
                 videoElement.oncanplay = null;
                 videoElement.canplaythrough = null;
                 videoElement.onloadeddata = null;
+                videoElement.onenterpictureinpicture = null;
+                videoElement.onleavepictureinpicture = null;
                 videoElement.onvolumechange = null;
                 videoElement.onratechange = null;
                 videoElement.textTracks.onchange = null;
@@ -763,8 +821,8 @@ HTMLVideo.canPlayStream = function(stream) {
 HTMLVideo.manifest = {
     name: 'HTMLVideo',
     external: false,
-    props: ['stream', 'loaded', 'paused', 'time', 'duration', 'buffering', 'buffered', 'audioTracks', 'selectedAudioTrackId', 'subtitlesTracks', 'selectedSubtitlesTrackId', 'subtitlesOffset', 'subtitlesSize', 'subtitlesTextColor', 'subtitlesBackgroundColor', 'subtitlesOutlineColor', 'subtitlesOpacity', 'volume', 'muted', 'playbackSpeed', 'videoScale', 'fullscreen'],
-    commands: ['load', 'unload', 'destroy'],
+    props: ['stream', 'loaded', 'paused', 'time', 'duration', 'buffering', 'buffered', 'audioTracks', 'selectedAudioTrackId', 'subtitlesTracks', 'selectedSubtitlesTrackId', 'subtitlesOffset', 'subtitlesSize', 'subtitlesTextColor', 'subtitlesBackgroundColor', 'subtitlesOutlineColor', 'subtitlesOpacity', 'volume', 'muted', 'playbackSpeed', 'videoScale', 'fullscreen', 'pictureInPicturePossible', 'pictureInPictureActive'],
+    commands: ['load', 'unload', 'destroy', 'enterPictureInPicture', 'exitPictureInPicture', 'togglePictureInPicture'],
     events: ['propValue', 'propChanged', 'ended', 'error', 'subtitlesTrackLoaded', 'audioTrackLoaded']
 };
 

--- a/src/HTMLVideo/pictureInPicture.js
+++ b/src/HTMLVideo/pictureInPicture.js
@@ -1,0 +1,13 @@
+function isPictureInPicturePossible(videoElement, documentElement) {
+    return !!videoElement && !!documentElement && documentElement.pictureInPictureEnabled === true &&
+        typeof videoElement.requestPictureInPicture === 'function';
+}
+
+function isPictureInPictureActive(videoElement, documentElement) {
+    return !!videoElement && !!documentElement && documentElement.pictureInPictureElement === videoElement;
+}
+
+module.exports = {
+    isPictureInPicturePossible: isPictureInPicturePossible,
+    isPictureInPictureActive: isPictureInPictureActive
+};

--- a/src/error.js
+++ b/src/error.js
@@ -47,6 +47,10 @@ var ERROR = {
         MEDIA_ERR_SRC_NOT_SUPPORTED: {
             code: 83,
             message: 'Video is not supported'
+        },
+        PICTURE_IN_PICTURE_FAILED: {
+            code: 84,
+            message: 'Failed to start or stop Picture in Picture'
         }
     },
     WITH_HTML_SUBTITLES: {

--- a/tests/pictureInPicture.test.js
+++ b/tests/pictureInPicture.test.js
@@ -1,0 +1,28 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const pictureInPicture = require('../src/HTMLVideo/pictureInPicture');
+
+test('reports Picture in Picture as possible when the browser exposes the API', () => {
+    const video = { requestPictureInPicture() {} };
+    const documentElement = { pictureInPictureEnabled: true };
+
+    assert.equal(pictureInPicture.isPictureInPicturePossible(video, documentElement), true);
+});
+
+test('reports Picture in Picture as unavailable when browser support is missing', () => {
+    assert.equal(
+        pictureInPicture.isPictureInPicturePossible({ requestPictureInPicture() {} }, { pictureInPictureEnabled: false }),
+        false
+    );
+    assert.equal(
+        pictureInPicture.isPictureInPicturePossible({}, { pictureInPictureEnabled: true }),
+        false
+    );
+});
+
+test('reports the active Picture in Picture element', () => {
+    const video = {};
+
+    assert.equal(pictureInPicture.isPictureInPictureActive(video, { pictureInPictureElement: video }), true);
+    assert.equal(pictureInPicture.isPictureInPictureActive(video, { pictureInPictureElement: {} }), false);
+});


### PR DESCRIPTION
## Summary

- add `pictureInPicturePossible` and `pictureInPictureActive` properties to `HTMLVideo`
- add enter, exit, and toggle Picture in Picture commands
- report Picture in Picture lifecycle changes and non-critical request failures
- add focused capability-state tests

## Scope

This adds the browser-native HTML5 Picture in Picture contract to `@stremio/stremio-video`. It covers direct media and HLS playback whenever the browser exposes `document.pictureInPictureEnabled` and `HTMLVideoElement.requestPictureInPicture()`.

The native macOS AVPlayer/KSPlayer implementation still needs a corresponding shell-side adapter. The installed Stremio macOS native app contains that code path, but it is not part of this public repository.

## Validation

- `npm test`
- `node --check src/HTMLVideo/HTMLVideo.js`
- `node --check src/HTMLVideo/pictureInPicture.js`
- `node --check src/error.js`
- `git diff --check`
