### PR TITLE
Expose video timing metadata

### DIFF
--- a/src/withStreamingServer/fetchVideoParams.js
+++ b/src/withStreamingServer/fetchVideoParams.js
@@ -108,12 +108,24 @@ function fetchFilename(streamingServerURL, mediaURL, infoHash, fileIdx, behavior
     return Promise.resolve(decodeURIComponent(mediaURL.split('/').pop()));
 }
 
-function fetchVideoParams(streamingServerURL, mediaURL, infoHash, fileIdx, behaviorHints) {
+function fetchVideoParams(streamingServerURL, mediaURL, infoHash, fileIdx, behaviorHints, probe) {
     return Promise.allSettled([
         fetchOpensubtitlesParams(streamingServerURL, mediaURL, behaviorHints),
         fetchFilename(streamingServerURL, mediaURL, infoHash, fileIdx, behaviorHints)
     ]).then(function(results) {
-        var result = { hash: null, size: null, filename: null };
+        var videoStream = probe && Array.isArray(probe.streams) ?
+            probe.streams.find(function(stream) { return stream.track === 'video'; })
+            :
+            null;
+        var frameRate = videoStream && typeof videoStream.frameRate === 'number' && isFinite(videoStream.frameRate) && videoStream.frameRate > 0 ? videoStream.frameRate : null;
+        var duration = probe && probe.format && typeof probe.format.duration === 'number' && isFinite(probe.format.duration) && probe.format.duration > 0 ? probe.format.duration : null;
+        var result = {
+            hash: null,
+            size: null,
+            filename: null,
+            fpsMilli: frameRate !== null ? Math.round(frameRate * 1000) : null,
+            durationMs: duration !== null ? Math.round(duration * 1000) : null
+        };
 
         if (results[0].status === 'fulfilled') {
             result.hash = results[0].value.hash;

--- a/src/withStreamingServer/withStreamingServer.js
+++ b/src/withStreamingServer/withStreamingServer.js
@@ -131,17 +131,18 @@ function withStreamingServer(Video) {
                                     audioCodecs: audioCodecs,
                                     maxAudioChannels: maxAudioChannels
                                 });
-                                return (commandArgs.forceTranscoding ? Promise.resolve(false) : VideoWithStreamingServer.canPlayStream({ url: mediaURL }, canPlayStreamOptions))
+                                return (commandArgs.forceTranscoding ? Promise.resolve({ canPlay: false, probe: null }) : checkCanPlayStream({ url: mediaURL }, canPlayStreamOptions))
                                     .catch(function(error) {
                                         console.warn('Media probe error', error);
-                                        return false;
+                                        return { canPlay: false, probe: null };
                                     })
-                                    .then(function(canPlay) {
-                                        if (canPlay) {
+                                    .then(function(checkResult) {
+                                        if (checkResult.canPlay) {
                                             return {
                                                 mediaURL: mediaURL,
                                                 infoHash: infoHash,
                                                 fileIdx: fileIdx,
+                                                probe: checkResult.probe,
                                                 stream: {
                                                     url: mediaURL
                                                 }
@@ -168,6 +169,7 @@ function withStreamingServer(Video) {
                                             mediaURL: mediaURL,
                                             infoHash: infoHash,
                                             fileIdx: fileIdx,
+                                            probe: checkResult.probe,
                                             stream: {
                                                 url: url.resolve(commandArgs.streamingServerURL, '/hlsv2/' + id + '/master.m3u8?' + queryParams.toString()),
                                                 subtitles: Array.isArray(commandArgs.stream.subtitles) ?
@@ -207,7 +209,7 @@ function withStreamingServer(Video) {
 
                                 isPlayerLoaded(video, Video.manifest.props)
                                     .then(function() {
-                                        return fetchVideoParams(commandArgs.streamingServerURL, result.mediaURL, result.infoHash, result.fileIdx, commandArgs.stream.behaviorHints);
+                                        return fetchVideoParams(commandArgs.streamingServerURL, result.mediaURL, result.infoHash, result.fileIdx, commandArgs.stream.behaviorHints, result.probe);
                                     })
                                     .then(function(result) {
                                         if (commandArgs !== loadArgs) {
@@ -224,7 +226,7 @@ function withStreamingServer(Video) {
 
                                         // eslint-disable-next-line no-console
                                         console.error(error);
-                                        videoParams = { hash: null, size: null, filename: null };
+                                        videoParams = { hash: null, size: null, filename: null, fpsMilli: null, durationMs: null };
                                         onPropChanged('videoParams');
                                     });
                             })
@@ -348,12 +350,15 @@ function withStreamingServer(Video) {
         };
     }
 
-    VideoWithStreamingServer.canPlayStream = function(stream, options) {
+    function checkCanPlayStream(stream, options) {
         return supportsTranscoding()
             .then(function(supported) {
                 if (!supported) {
                     // we cannot probe the video in this case
-                    return Video.canPlayStream(stream);
+                    return Video.canPlayStream(stream)
+                        .then(function(canPlay) {
+                            return { canPlay: canPlay, probe: null };
+                        });
                 }
                 // probing normally gives more accurate results
                 var queryParams = new URLSearchParams([['mediaURL', stream.url]]);
@@ -385,13 +390,26 @@ function withStreamingServer(Video) {
                             return stream.track === 'audio' && options.audioCodecs.indexOf(stream.codec) !== -1;
                         });
 
-                        return isFormatSupported && areStreamsSupported && !hasEmbeddedSubtitles && supportedAudioTracks.length < 2;
+                        return {
+                            canPlay: isFormatSupported && areStreamsSupported && !hasEmbeddedSubtitles && supportedAudioTracks.length < 2,
+                            probe: probe
+                        };
                     })
                     .catch(function() {
                         // this uses content-type header in HTMLVideo which
                         // is unreliable, check can also fail due to CORS
-                        return Video.canPlayStream(stream);
+                        return Video.canPlayStream(stream)
+                            .then(function(canPlay) {
+                                return { canPlay: canPlay, probe: null };
+                            });
                     });
+            });
+    }
+
+    VideoWithStreamingServer.canPlayStream = function(stream, options) {
+        return checkCanPlayStream(stream, options)
+            .then(function(result) {
+                return result.canPlay;
             });
     };
 

--- a/src/withVideoParams/withVideoParams.js
+++ b/src/withVideoParams/withVideoParams.js
@@ -53,7 +53,7 @@ function withVideoParams(Video) {
                     var hash = stream.behaviorHints && typeof stream.behaviorHints.videoHash === 'string' ? stream.behaviorHints.videoHash : null;
                     var size = stream.behaviorHints && stream.behaviorHints.videoSize !== null && isFinite(stream.behaviorHints.videoSize) ? stream.behaviorHints.videoSize : null;
                     var filename = stream.behaviorHints && typeof stream.behaviorHints.filename === 'string' ? stream.behaviorHints.filename : null;
-                    return { hash: hash, size: size, filename: filename };
+                    return { hash: hash, size: size, filename: filename, fpsMilli: null, durationMs: null };
                 }
                 default: {
                     return videoPropValue;


### PR DESCRIPTION
`videoParams` now carries `fpsMilli` and `durationMs`.

Both come from the probe `canPlayStream` already runs, so there is no extra request — `checkCanPlayStream` returns the probe next to the boolean and `canPlayStream` keeps its old signature.