### PR TITLE
Fix deferred WebOS subtitle toggles

### DIFF
--- a/src/WebOsVideo/WebOsVideo.js
+++ b/src/WebOsVideo/WebOsVideo.js
@@ -146,6 +146,10 @@ function WebOsVideo(options) {
 
     var disabledSubs = true;
 
+    var pendingSubtitlesEnabled = null;
+
+    var subtitlesToggleTimer = null;
+
     var currentSubTrack = false;
 
     var currentAudioTrack = false;
@@ -165,18 +169,31 @@ function WebOsVideo(options) {
         char_opacity: 255
     };
 
-    var toggleSubtitles = function (status) {
-        if (!videoElement.mediaId) return;
+    var applyPendingSubtitlesToggle = function () {
+        if (pendingSubtitlesEnabled === null || !videoElement.mediaId) return;
 
-        disabledSubs = !status;
-
+        var enabled = pendingSubtitlesEnabled;
+        pendingSubtitlesEnabled = null;
+        if (subtitlesToggleTimer !== null) {
+            clearInterval(subtitlesToggleTimer);
+            subtitlesToggleTimer = null;
+        }
         luna({
             method: 'setSubtitleEnable',
             parameters: {
                 'mediaId': videoElement.mediaId,
-                'enable': status
+                'enable': enabled
             }
         });
+    };
+
+    var toggleSubtitles = function (status) {
+        disabledSubs = !status;
+        pendingSubtitlesEnabled = status;
+        applyPendingSubtitlesToggle();
+        if (pendingSubtitlesEnabled !== null && subtitlesToggleTimer === null) {
+            subtitlesToggleTimer = setInterval(applyPendingSubtitlesToggle, 300);
+        }
     };
 
     var styleElement = document.createElement('style');
@@ -927,6 +944,11 @@ function WebOsVideo(options) {
                 break;
             }
             case 'unload': {
+                pendingSubtitlesEnabled = null;
+                if (subtitlesToggleTimer !== null) {
+                    clearInterval(subtitlesToggleTimer);
+                    subtitlesToggleTimer = null;
+                }
                 stream = null;
                 startTime = null;
                 Array.from(videoElement.textTracks).forEach(function(track) {

--- a/src/WebOsVideo/WebOsVideo.js
+++ b/src/WebOsVideo/WebOsVideo.js
@@ -169,19 +169,26 @@ function WebOsVideo(options) {
         char_opacity: 255
     };
 
-    var applyPendingSubtitlesToggle = function () {
-        if (pendingSubtitlesEnabled === null || !videoElement.mediaId) return;
-
-        var enabled = pendingSubtitlesEnabled;
+    var clearPendingSubtitlesToggle = function () {
         pendingSubtitlesEnabled = null;
         if (subtitlesToggleTimer !== null) {
             clearInterval(subtitlesToggleTimer);
             subtitlesToggleTimer = null;
         }
+    };
+
+    var applyPendingSubtitlesToggle = function () {
+        if (pendingSubtitlesEnabled === null) return;
+
+        var mediaId = videoElement.mediaId;
+        if (!mediaId || mediaId === '<invalid mediaId>') return;
+
+        var enabled = pendingSubtitlesEnabled;
+        clearPendingSubtitlesToggle();
         luna({
             method: 'setSubtitleEnable',
             parameters: {
-                'mediaId': videoElement.mediaId,
+                'mediaId': mediaId,
                 'enable': enabled
             }
         });
@@ -871,6 +878,9 @@ function WebOsVideo(options) {
                 // not sure about this
                 // command('unload');
                 if (commandArgs && commandArgs.stream && typeof commandArgs.stream.url === 'string') {
+                    if (stream !== null) {
+                        clearPendingSubtitlesToggle();
+                    }
                     stream = commandArgs.stream;
                     startTime = commandArgs.time;
 
@@ -944,11 +954,7 @@ function WebOsVideo(options) {
                 break;
             }
             case 'unload': {
-                pendingSubtitlesEnabled = null;
-                if (subtitlesToggleTimer !== null) {
-                    clearInterval(subtitlesToggleTimer);
-                    subtitlesToggleTimer = null;
-                }
+                clearPendingSubtitlesToggle();
                 stream = null;
                 startTime = null;
                 Array.from(videoElement.textTracks).forEach(function(track) {


### PR DESCRIPTION
Queues native subtitle enable/disable requests until webOS exposes the media ID.

Related to Stremio/stremio-theater#349 and Stremio/stremio-tasks#539.