### PR TITLE
Preserve streaming server path prefixes

### DIFF
--- a/src/withStreamingServer/convertStream.js
+++ b/src/withStreamingServer/convertStream.js
@@ -1,4 +1,4 @@
-var url = require('url');
+var resolveStreamingServerEndpoint = require('./resolveStreamingServerEndpoint');
 var magnet = require('magnet-uri');
 var createTorrent = require('./createTorrent');
 
@@ -12,7 +12,7 @@ function buildProxyUrl(streamingServerURL, streamURL, requestHeaders, responseHe
     Object.entries(responseHeaders).forEach(function(entry) {
         proxyOptions.append('r', entry[0] + ':' + entry[1]);
     });
-    return url.resolve(streamingServerURL, '/proxy/' + proxyOptions.toString() + parsedStreamURL.pathname) + parsedStreamURL.search;
+    return resolveStreamingServerEndpoint(streamingServerURL, '/proxy/' + proxyOptions.toString() + parsedStreamURL.pathname) + parsedStreamURL.search;
 }
 
 function convertStream(streamingServerURL, stream, seriesInfo, streamingServerSettings) {

--- a/src/withStreamingServer/createTorrent.js
+++ b/src/withStreamingServer/createTorrent.js
@@ -1,4 +1,4 @@
-var url = require('url');
+var resolveStreamingServerEndpoint = require('./resolveStreamingServerEndpoint');
 
 function buildTorrent(streamingServerURL, infoHash, fileIdx, sources) {
     var query = Array.isArray(sources) && sources.length > 0 ?
@@ -8,7 +8,7 @@ function buildTorrent(streamingServerURL, infoHash, fileIdx, sources) {
         :
         '';
     return {
-        url: url.resolve(streamingServerURL, '/' + encodeURIComponent(infoHash) + '/' + encodeURIComponent(fileIdx)) + query,
+        url: resolveStreamingServerEndpoint(streamingServerURL, '/' + encodeURIComponent(infoHash) + '/' + encodeURIComponent(fileIdx)) + query,
         infoHash: infoHash,
         fileIdx: fileIdx,
         sources: sources
@@ -52,7 +52,7 @@ function createTorrent(streamingServerURL, infoHash, fileIdx, sources, seriesInf
         body.guessFileIdx = false;
     }
 
-    return fetch(url.resolve(streamingServerURL, '/' + encodeURIComponent(infoHash) + '/create'), {
+    return fetch(resolveStreamingServerEndpoint(streamingServerURL, '/' + encodeURIComponent(infoHash) + '/create'), {
         method: 'POST',
         headers: {
             'content-type': 'application/json'

--- a/src/withStreamingServer/fetchVideoParams.js
+++ b/src/withStreamingServer/fetchVideoParams.js
@@ -1,4 +1,4 @@
-var url = require('url');
+var resolveStreamingServerEndpoint = require('./resolveStreamingServerEndpoint');
 
 function fetchOpensubtitlesParams(streamingServerURL, mediaURL, behaviorHints) {
     var hash = behaviorHints && typeof behaviorHints.videoHash === 'string' ? behaviorHints.videoHash : null;
@@ -8,7 +8,7 @@ function fetchOpensubtitlesParams(streamingServerURL, mediaURL, behaviorHints) {
     }
 
     var queryParams = new URLSearchParams([['videoUrl', mediaURL]]);
-    return fetch(url.resolve(streamingServerURL, '/opensubHash?' + queryParams.toString()))
+    return fetch(resolveStreamingServerEndpoint(streamingServerURL, '/opensubHash?' + queryParams.toString()))
         .then(function(resp) {
             if (resp.ok) {
                 return resp.json();
@@ -52,7 +52,7 @@ function fetchFilename(streamingServerURL, mediaURL, infoHash, fileIdx, behavior
         var hasSpecificFileIdx = fileIdxNum !== null && fileIdxNum !== -1 && isFinite(fileIdxNum);
 
         if (hasSpecificFileIdx) {
-            return fetch(url.resolve(streamingServerURL, '/' + encodeURIComponent(infoHash) + '/' + encodeURIComponent(fileIdx) + '/stats.json'))
+            return fetch(resolveStreamingServerEndpoint(streamingServerURL, '/' + encodeURIComponent(infoHash) + '/' + encodeURIComponent(fileIdx) + '/stats.json'))
                 .then(function(resp) {
                     if (resp.ok) {
                         return resp.json();
@@ -69,7 +69,7 @@ function fetchFilename(streamingServerURL, mediaURL, infoHash, fileIdx, behavior
                 });
         }
 
-        return fetch(url.resolve(streamingServerURL, '/' + encodeURIComponent(infoHash) + '/stats.json'))
+        return fetch(resolveStreamingServerEndpoint(streamingServerURL, '/' + encodeURIComponent(infoHash) + '/stats.json'))
             .then(function(resp) {
                 if (resp.ok) {
                     return resp.json();

--- a/src/withStreamingServer/resolveStreamingServerEndpoint.js
+++ b/src/withStreamingServer/resolveStreamingServerEndpoint.js
@@ -1,0 +1,13 @@
+var url = require('url');
+
+function resolveStreamingServerEndpoint(streamingServerURL, endpoint) {
+    var baseURL = url.parse(streamingServerURL);
+    baseURL.pathname = baseURL.pathname || '/';
+    if (baseURL.pathname.slice(-1) !== '/') {
+        baseURL.pathname += '/';
+    }
+
+    return url.resolve(url.format(baseURL), endpoint.replace(/^\/+/, ''));
+}
+
+module.exports = resolveStreamingServerEndpoint;

--- a/src/withStreamingServer/withStreamingServer.js
+++ b/src/withStreamingServer/withStreamingServer.js
@@ -1,5 +1,5 @@
 var EventEmitter = require('eventemitter3');
-var url = require('url');
+var resolveStreamingServerEndpoint = require('./resolveStreamingServerEndpoint');
 var hat = require('hat');
 var cloneDeep = require('lodash.clonedeep');
 var deepFreeze = require('deep-freeze');
@@ -171,12 +171,12 @@ function withStreamingServer(Video) {
                                             fileIdx: fileIdx,
                                             probe: checkResult.probe,
                                             stream: {
-                                                url: url.resolve(commandArgs.streamingServerURL, '/hlsv2/' + id + '/master.m3u8?' + queryParams.toString()),
+                                                url: resolveStreamingServerEndpoint(commandArgs.streamingServerURL, '/hlsv2/' + id + '/master.m3u8?' + queryParams.toString()),
                                                 subtitles: Array.isArray(commandArgs.stream.subtitles) ?
                                                     commandArgs.stream.subtitles.map(function(track) {
                                                         return Object.assign({}, track, {
                                                             url: typeof track.url === 'string' ?
-                                                                url.resolve(commandArgs.streamingServerURL, '/subtitles.vtt?' + new URLSearchParams([['from', track.url]]).toString())
+                                                                resolveStreamingServerEndpoint(commandArgs.streamingServerURL, '/subtitles.vtt?' + new URLSearchParams([['from', track.url]]).toString())
                                                                 :
                                                                 track.url
                                                         });
@@ -264,7 +264,7 @@ function withStreamingServer(Video) {
                                             // fallback is used in case server conversion fails (if server is offline)
                                             fallbackUrl: track.url,
                                             url: typeof track.url === 'string' ?
-                                                url.resolve(loadArgs.streamingServerURL, '/subtitles.vtt?' + new URLSearchParams([['from', track.url]]).toString())
+                                                resolveStreamingServerEndpoint(loadArgs.streamingServerURL, '/subtitles.vtt?' + new URLSearchParams([['from', track.url]]).toString())
                                                 :
                                                 track.url
                                         });
@@ -362,7 +362,7 @@ function withStreamingServer(Video) {
                 }
                 // probing normally gives more accurate results
                 var queryParams = new URLSearchParams([['mediaURL', stream.url]]);
-                return fetch(url.resolve(options.streamingServerURL, '/hlsv2/probe?' + queryParams.toString()))
+                return fetch(resolveStreamingServerEndpoint(options.streamingServerURL, '/hlsv2/probe?' + queryParams.toString()))
                     .then(function(resp) {
                         return resp.json();
                     })


### PR DESCRIPTION
## Summary

Custom streaming server URLs can include a path prefix such as `https://example.com/service/`. The current endpoint resolution uses leading slash paths, so requests are resolved from the origin root and `/service/` is dropped.

This change adds one streaming server endpoint resolver and uses it for proxy, torrent, stats, OpenSub hash, HLS, probe, and subtitle requests. Root streaming server URLs keep their existing behavior.

This fixes the path prefix problem described in item 2 of Stremio/stremio-web#627. It does not change basic authentication or cookie behavior.

## Checks

- `npm run lint` with 0 errors
- path prefix and root URL compatibility checks
- module checks for torrent creation, proxying, OpenSub hash, and stats requests
