### PR TITLE
WebOsVideo: optional showUnsupportedAudioTracks load arg

### DIFF
--- a/src/WebOsVideo/WebOsVideo.js
+++ b/src/WebOsVideo/WebOsVideo.js
@@ -142,6 +142,8 @@ function WebOsVideo(options) {
 
     var isLoaded = null;
 
+    var showUnsupportedAudioTracks = false;
+
     var subSize = 75;
 
     var disabledSubs = true;
@@ -359,7 +361,7 @@ function WebOsVideo(options) {
                 }
                 if (((tracksData || {}).audio || []).length) {
                     tracksData.audio.forEach(function(track) {
-                        if (device.unsupportedAudio.includes(track.codec || '')) {
+                        if (!showUnsupportedAudioTracks && device.unsupportedAudio.includes(track.codec || '')) {
                             return;
                         }
                         var audioTrackId = nrAudio;
@@ -883,6 +885,7 @@ function WebOsVideo(options) {
                     }
                     stream = commandArgs.stream;
                     startTime = commandArgs.time;
+                    showUnsupportedAudioTracks = commandArgs.showUnsupportedAudioTracks === true;
 
                     onPropChanged('stream');
                     videoElement.autoplay = typeof commandArgs.autoplay === 'boolean' ? commandArgs.autoplay : true;


### PR DESCRIPTION
Implements the player half of Stremio/stremio-features#1904.

When the `load` command carries `showUnsupportedAudioTracks: true`, WebOsVideo lists embedded audio tracks whose codecs are in `device.unsupportedAudio` (DTS/TrueHD) instead of hiding them. Some TVs decode these codecs even though `tv.model.edidType` doesn't advertise passthrough — 2023/2024 LG models ship a native DTS decoder, and modified TVs decode both.

Defaults to false, so behavior is unchanged unless the app opts in. Only WebOsVideo reads the flag. I'll follow up with the settings toggle in stremio-web (and the setting in stremio-core) if this approach is acceptable.