### PR TITLE
Reset video scale between streams

### DIFF
--- a/src/HTMLVideo/HTMLVideo.js
+++ b/src/HTMLVideo/HTMLVideo.js
@@ -673,6 +673,7 @@ function HTMLVideo(options) {
                 videoElement.removeAttribute('src');
                 videoElement.load();
                 videoElement.currentTime = 0;
+                videoElement.style.objectFit = 'contain';
                 onPropChanged('stream');
                 onPropChanged('loaded');
                 onPropChanged('paused');
@@ -684,6 +685,7 @@ function HTMLVideo(options) {
                 onPropChanged('selectedSubtitlesTrackId');
                 onPropChanged('audioTracks');
                 onPropChanged('selectedAudioTrackId');
+                onPropChanged('videoScale');
                 onPropChanged('fullscreen');
                 break;
             }

--- a/src/ShellVideo/ShellVideo.js
+++ b/src/ShellVideo/ShellVideo.js
@@ -581,12 +581,15 @@ function ShellVideo(options) {
                     buffered: null,
                     aid: null,
                     sid: null,
+                    videoScale: 'contain',
                     assSubtitlesStylingActive: false,
                 };
                 assSubtitlesStylingEnabled = false;
                 avgDuration = 0;
                 durationReady = false;
                 ipc.send('mpv-command', ['stop']);
+                ipc.send('mpv-set-prop', ['keepaspect', true]);
+                ipc.send('mpv-set-prop', ['panscan', 0.0]);
                 onPropChanged('loaded');
                 onPropChanged('stream');
                 onPropChanged('paused');
@@ -597,6 +600,7 @@ function ShellVideo(options) {
                 onPropChanged('muted');
                 onPropChanged('subtitlesTracks');
                 onPropChanged('selectedSubtitlesTrackId');
+                onPropChanged('videoScale');
                 if (wasASSSubtitlesStylingActive) {
                     onPropChanged('assSubtitlesStylingActive');
                 }


### PR DESCRIPTION
Reset HTML and Shell video scale to Fit on unload so the reported state matches the renderer when the next stream starts.