### PR TITLE
Prefer direct hwdec on Windows

### DIFF
--- a/src/ShellVideo/ShellVideo.js
+++ b/src/ShellVideo/ShellVideo.js
@@ -510,7 +510,8 @@ function ShellVideo(options) {
                             !!commandArgs.hardwareDecoding;
 
                         // Hardware decoding
-                        var hwdecValue = commandArgs.hardwareDecoding ? (gpuProcessing ? 'd3d11va' : 'auto-copy') : 'no';
+                        var hwdecAuto = commandArgs.platform === 'windows' ? 'auto' : 'auto-copy';
+                        var hwdecValue = commandArgs.hardwareDecoding ? (gpuProcessing ? 'd3d11va' : hwdecAuto) : 'no';
                         ipc.send('mpv-set-prop', ['hwdec', hwdecValue]);
 
                         // GPU video processing


### PR DESCRIPTION
`auto-copy` forced d3d11va-copy (GPU → RAM → GPU per frame) for everyone without RTX processing. The shell already runs on gpu-context=d3d11, so `auto` picks d3d11va directly and still falls back to the copy modes if that fails. Non-Windows unchanged.

Related: Stremio/stremio-bugs#2734, Stremio/stremio-bugs#2627